### PR TITLE
Search by format terms + ui optimizations

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -1,0 +1,6 @@
+module.exports = {
+  STANDARD_FORMAT_TERMS: [
+            'Vinyl', 'LP', 'Album', 'Reissue', 'Repress', 'Stereo', 'Gatefold', 
+            '12"', '7"', 'Limited Edition', 'Compilation', 'Deluxe Edition', 'Numbered', 'Promo'
+        ]   
+}

--- a/routes/albumRoutes.js
+++ b/routes/albumRoutes.js
@@ -8,6 +8,7 @@ const Vinyl = require('../models/Vinyl');
 
 const { requireAuth, requireAdmin } = require('../middleware/authMiddleware'); // Protect routes
 const User = require('../models/User');
+const { STANDARD_FORMAT_TERMS } = require('../config/constants');
 
 async function getAdminId() {
     const admin = await User.findOne({ isAdmin: true }).select('_id');
@@ -109,14 +110,13 @@ router.get('/', requireAuth, async (req, res) => {
 router.get('/collection', requireAuth, async (req, res) => {
     try {
         const adminId = await getAdminId();
-        const { search, type, format, location, genre } = req.query;
+        const { search, type, format, location, genre, formatTerms} = req.query;
         const page = parseInt(req.query.page) || 1;
         const limit = parseInt(req.query.limit) || 25;
 
         let query = { owner: adminId, in_wishlist: false };
         let conditions = []; 
 
-        
         if (search) {
             const regex = new RegExp(search, 'i');
             conditions.push({ 
@@ -152,6 +152,12 @@ router.get('/collection', requireAuth, async (req, res) => {
 
         if (genre) {
             query.genre = new RegExp(genre, 'i');
+        }
+
+        if (formatTerms && formatTerms.length > 0) {
+            conditions = [...conditions, ...formatTerms.split(',').map(term => ({
+                format_type: { $regex: term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' }
+            }))];
         }
 
         
@@ -198,11 +204,13 @@ router.get('/collection', requireAuth, async (req, res) => {
             querySearch: search || '',
             queryLocation: location || '',
             queryGenre: genre || '',
+            currentFormatTerms: formatTerms || '',
             activeFilters: filterMap[type] || [],
             locations: await Item.distinct('location', { owner: adminId }),
             genres: (type && type !== 'all') ? await Item.distinct('genre', Object.assign({ owner: adminId, genre: { $nin: ['', null] } }, 
                 type === 'music' ? { $or: [{ kind: 'Music' }, { kind: { $exists: false } }] } : { kind: { music: 'Music', books: 'Book', dvd: 'Dvd' }[type] }
-            )) : []
+            )) : [],
+            standardFormatTerms: STANDARD_FORMAT_TERMS,
         });
 
     } catch (err) {
@@ -325,12 +333,7 @@ router.get('/confirm-vinyl/:id', requireAuth, async (req, res) => {
     try {
         const url = `https://api.discogs.com/releases/${discogsId}?token=${token}`;
         const response = await axios.get(url, { headers: { 'User-Agent': 'DVinylApp/1.0' } });
-        const data = response.data;
-
-        const standardTerms = [
-            'Vinyl', 'LP', 'Album', 'Reissue', 'Repress', 'Stereo', 'Gatefold', 
-            '12"', '7"', 'Limited Edition', 'Compilation', 'Deluxe Edition', 'Numbered', 'Promo'
-        ];        
+        const data = response.data;       
 
         let formatType = [];
         let variantColor = [];
@@ -350,7 +353,7 @@ router.get('/confirm-vinyl/:id', requireAuth, async (req, res) => {
             if (bestFormat.text) {
                 const parts = bestFormat.text.split(',').map(p => p.trim());
                 parts.forEach(part => {
-                    if (standardTerms.includes(part)) {
+                    if (STANDARD_FORMAT_TERMS.includes(part)) {
                         if (!formatType.includes(part)) formatType.push(part);
                     } else {
                         if (!variantColor.includes(part)) variantColor.push(part);
@@ -360,7 +363,7 @@ router.get('/confirm-vinyl/:id', requireAuth, async (req, res) => {
 
             if (bestFormat.descriptions) {
                 bestFormat.descriptions.forEach(desc => {
-                    if (standardTerms.includes(desc)) {
+                    if (STANDARD_FORMAT_TERMS.includes(desc)) {
                         if (!formatType.includes(desc)) formatType.push(desc);
                     } else {
                         if (!variantColor.includes(desc)) {
@@ -675,7 +678,6 @@ router.post('/import/discogs', requireAuth, async (req, res) => {
         let totalImported = 0;
         let totalProcessed = 0;
         let hasMore = true;
-        const standardTerms = ['Vinyl', 'LP', 'Album', 'Reissue', 'Repress', 'Stereo', 'Gatefold', '12"', '7"'];
         
         const isWishlist = (type === 'wishlist');
         const apiUrl = isWishlist ? `https://api.discogs.com/users/${username}/wants` : `https://api.discogs.com/users/${username}/collection/folders/0/releases`;
@@ -739,7 +741,7 @@ router.post('/import/discogs', requireAuth, async (req, res) => {
                 let formatType = [info.formats?.[0]?.name].filter(Boolean);
                 let variantColor = [];
                 if (info.formats?.[0]?.descriptions) {
-                    info.formats[0].descriptions.forEach(d => standardTerms.includes(d) ? formatType.push(d) : variantColor.push(d));
+                    info.formats[0].descriptions.forEach(d => STANDARD_FORMAT_TERMS.includes(d) ? formatType.push(d) : variantColor.push(d));
                 }
                 const rawFormat = info.formats?.[0]?.name.toLowerCase() || 'vinyl';
                 let mediaType = rawFormat.includes('cd') ? 'cd' : (rawFormat.includes('cassette') ? 'cassette' : 'vinyl');

--- a/views/add-book.ejs
+++ b/views/add-book.ejs
@@ -21,7 +21,7 @@
                     <div class="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
                         <i class="fa-solid fa-search opacity-50"></i>
                     </div>
-                    <input type="text" name="query" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_book.search_placeholder') || 'Titre, Auteur ou ISBN...' %>" required>
+                    <input type="text" name="query" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_book.search_placeholder') || 'Titre, Auteur ou ISBN...' %>" required autofocus>
                 </div>
                 
                 <button type="submit" class="w-full md:w-auto px-8 py-4 bg-primary-theme text-white font-bold rounded-xl hover:brightness-110 transition-all shadow-lg active:scale-95 duration-100">

--- a/views/add-dvd.ejs
+++ b/views/add-dvd.ejs
@@ -21,7 +21,7 @@
                     <div class="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
                         <i class="fa-solid fa-search opacity-50"></i>
                     </div>
-                    <input type="text" name="query" value="<%= locals.scanned_barcode || '' %>" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_dvd.search_placeholder') || 'Titre, Réalisateur ou Code-barres...' %>" required>
+                    <input type="text" name="query" value="<%= locals.scanned_barcode || '' %>" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_dvd.search_placeholder') || 'Titre, Réalisateur ou Code-barres...' %>" required autofocus>
                 </div>
                 
                 <button type="submit" class="w-full md:w-auto px-8 py-4 bg-primary-theme text-white font-bold rounded-xl hover:brightness-110 transition-all shadow-lg active:scale-95 duration-100">

--- a/views/add-vinyl.ejs
+++ b/views/add-vinyl.ejs
@@ -48,7 +48,7 @@
                     <div class="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
                         <i class="fa-solid fa-search opacity-50"></i>
                     </div>
-                    <input type="text" name="query" value="<%= locals.searchQuery || '' %>" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_vinyl.search_placeholder') %>" required>
+                    <input type="text" name="query" value="<%= locals.searchQuery || '' %>" class="block w-full p-4 pl-12 border border-transparent rounded-xl bg-black/5 dark:bg-white/5 focus:ring-2 focus:ring-primary-theme focus:bg-transparent placeholder-opacity-50 text-base transition-all" placeholder="<%= t('add_vinyl.search_placeholder') %>" required autofocus>
                 </div>
                 
                 <button type="submit" class="w-full md:w-auto px-8 py-4 bg-primary-theme text-white font-bold rounded-xl hover:brightness-110 transition-all shadow-lg active:scale-95 duration-100">

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -2,12 +2,49 @@
 
 <div class="max-w-screen-xl mx-auto px-4 md:px-0 pb-12">
     
-    <div class="pt-6 mb-6">
+    <div class="pt-6 mb-6 flex items-center justify-between">
         <h1 class="text-3xl font-bold transition-colors">
             <%= t('collection.title') %>
         </h1>
-    </div>
+        <% if (user.isAdmin) { %>
+        <%
+        const addRoutes = { music: '/add-vinyl', books: '/add-book', dvd: '/add-dvd' };
+        const addRoute = addRoutes[currentType];
+        %>
+        <div class="flex gap-2">
 
+            <% if (addRoute) { %>
+                <a href="<%= addRoute %>"
+                    class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group"
+                    title="<%= t('collection.add') %>">
+                    <i class="fa-solid fa-plus group-hover:scale-110 transition-transform"></i>
+                    <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('collection.add') %></span>
+                </a>
+            <% } %>
+
+            <% if (currentType === 'music') { %>
+                <button onclick="openEstimateModal()" 
+                    class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group" 
+                    title="<%= t('index.btn_estimate') %>">
+                    <i class="fa-solid fa-calculator group-hover:scale-110 transition-transform"></i>
+                    <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('index.btn_estimate') %></span>
+                </button>
+            <% } %>
+
+            <% if (user.discogsUsername && currentType === 'music') { %>
+                <button onclick="refreshCollection()" id="refreshBtn" 
+                    class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group" 
+                    title="<%= t('collection.refresh_tooltip') %>">
+                    <i class="fa-solid fa-sync group-hover:rotate-180 transition-transform duration-500"></i>
+                    <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('collection.refresh') %></span>
+                </button>
+            <% } %>
+
+        </div>
+    <% } %>
+
+    </div>
+    
     <div class="space-y-6 mb-8">
                             
         <div class="flex flex-wrap gap-2 mb-8" id="formatFilters">
@@ -22,19 +59,19 @@
 
             <% if (currentType === 'all') { %>
                 <% mainTypes.forEach(type => { %>
-                    <button onclick="updateURLParams('type', '<%= type.id %>')" 
+                    <button onclick="currentType = '<%= type.id %>'; reloadPage();" 
                         class="px-4 py-2 rounded-full text-xs font-bold transition-all active:scale-95 <%= currentType === type.id ? 'bg-primary-theme text-white shadow-lg' : 'bg-black/5 dark:bg-white/10 opacity-60' %>">
                         <%= type.label %>
                     </button>
                 <% }) %>
             <% } else { %>
-                <button onclick="updateURLParams('type', 'all')" 
+                <button onclick="currentType = 'all'; reloadPage();" 
                     class="px-4 py-2 rounded-full text-xs font-bold transition-all active:scale-95 bg-black/5 dark:bg-white/10 opacity-60">
                     <i class="fa-solid fa-arrow-left mr-2"></i> <%= t('common.all') %>
                 </button>
 
                 <% activeFilters.forEach(filter => { %>
-                    <button onclick="updateURLParams('format', '<%= filter.id %>')" 
+                    <button onclick="currentFormat = '<%= filter.id %>'; reloadPage();" 
                         class="px-4 py-2 rounded-full text-xs font-bold transition-all active:scale-95 <%= currentFormat === filter.id ? 'bg-primary-theme text-white shadow-lg' : 'bg-black/5 dark:bg-white/10 opacity-60' %>">
                         <%= filter.label %>
                     </button>
@@ -47,11 +84,11 @@
                 <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
                     <i class="fa-solid fa-search opacity-50"></i>
                 </div>
-                <input type="text" id="filterInput" class="block w-full p-2.5 pl-10 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme placeholder-opacity-50" value="<%= locals.querySearch || '' %>" placeholder="<%= t('collection.filter_placeholder') %>">
+                <input type="text" id="filterInput" class="filter-input-textbox block w-full p-2.5 pl-10 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme placeholder-opacity-50" value="<%= locals.querySearch || '' %>" placeholder="<%= t('collection.filter_placeholder') %>">
             </div>
 
             <div class="w-full md:w-48">
-                <input type="text" id="locationInput" list="locations-list" placeholder="<%= t('common.location') %>" value="<%= locals.queryLocation || '' %>" class="block w-full p-2.5 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme outline-none placeholder-opacity-50">
+                <input type="text" id="locationInput" list="locations-list" placeholder="<%= t('common.location') %>" value="<%= locals.queryLocation || '' %>" class="filter-input-textbox block w-full p-2.5 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme outline-none placeholder-opacity-50">
                 <datalist id="locations-list">
                     <% locations.forEach(loc => { %> <option value="<%= loc %>"></option> <% }) %>
                 </datalist>
@@ -59,49 +96,36 @@
 
             <% if (currentType !== 'all') { %>
             <div class="w-full md:w-48">
-                <input type="text" id="genreInput" list="genres-list" placeholder="Genre / Style" value="<%= locals.queryGenre || '' %>" class="block w-full p-2.5 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme outline-none placeholder-opacity-50">
+                <input type="text" id="genreInput" list="genres-list" placeholder="Genre / Style" value="<%= locals.queryGenre || '' %>" class="filter-input-textbox block w-full p-2.5 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme outline-none placeholder-opacity-50">
                 <datalist id="genres-list">
                     <% genres.forEach(gen => { %> <option value="<%= gen %>"></option> <% }) %>
                 </datalist>
             </div>
             <% } %>
 
-            <% if (user.isAdmin) { %>
-                <%
-                const addRoutes = { music: '/add-vinyl', books: '/add-book', dvd: '/add-dvd' };
-                const addRoute = addRoutes[currentType];
-                %>
-                <div class="flex gap-2">
-
-                    <% if (addRoute) { %>
-                        <a href="<%= addRoute %>"
-                            class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group"
-                            title="<%= t('collection.add') %>">
-                            <i class="fa-solid fa-plus group-hover:scale-110 transition-transform"></i>
-                            <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('collection.add') %></span>
-                        </a>
-                    <% } %>
-
-                    <% if (currentType === 'music') { %>
-                        <button onclick="openEstimateModal()" 
-                            class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group" 
-                            title="<%= t('index.btn_estimate') %>">
-                            <i class="fa-solid fa-calculator group-hover:scale-110 transition-transform"></i>
-                            <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('index.btn_estimate') %></span>
-                        </button>
-                    <% } %>
-
-                    <% if (user.discogsUsername && currentType === 'music') { %>
-                        <button onclick="refreshCollection()" id="refreshBtn" 
-                            class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group" 
-                            title="<%= t('collection.refresh_tooltip') %>">
-                            <i class="fa-solid fa-sync group-hover:rotate-180 transition-transform duration-500"></i>
-                            <span class="hidden md:inline text-xs font-bold uppercase tracking-widest"><%= t('collection.refresh') %></span>
-                        </button>
-                    <% } %>
-
+            <% if (currentType === 'music'){ %>
+            <div class="w-full md:w-36">
+                <button onclick="this.nextElementSibling.classList.toggle('hidden')" class="block w-full p-2.5 text-sm card-theme rounded-lg border focus:ring-1 focus:ring-primary-theme outline-none placeholder-opacity-50 text-left">
+                    Format <span>▾</span>
+                </button>
+                <div id="format-multi-select" class="w-full hidden absolute z-20 card-theme rounded-lg p-2 mt-1 shadow-lg border md:w-36">
+                    <% 
+                    const currentFormatTermsArr = locals.currentFormatTerms?.split(',') ?? [];
+                    standardFormatTerms.forEach(formatTerm => {%> 
+                        <label class="flex items-center gap-2 p-1 p-2 text-sm rounded hover:bg-black/5 dark:hover:bg-white/10 cursor-pointer">
+                            <input type="checkbox" class="accent-primary-theme" value="<%= formatTerm %>" <%= currentFormatTermsArr.includes(formatTerm) ? 'checked' : '' %>> <%= formatTerm %>
+                        </label>
+                    <% });%>
                 </div>
+            </div>
             <% } %>
+            <div class="w-full md:w-12">
+                <button onclick="reloadPage()"
+                    class="block w-full p-2.5 text-sm rounded-lg border hover:text-primary-theme hover:border-primary-theme card-theme transition-all">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                </button>
+
+            </div>
         </div>
     </div>
 
@@ -187,7 +211,7 @@
             <span class="text-xs font-bold uppercase tracking-widest opacity-40"><%= t('common.show') %></span>
             <div class="flex bg-black/5 dark:bg-white/5 p-1 rounded-xl">
                 <% [25, 50, 100].forEach(num => { %>
-                    <button onclick="changeLimit(<%= num %>)" 
+                    <button onclick="currentLimit = <%= num %>; reloadPage();" 
                         class="px-3 py-1.5 text-xs font-bold rounded-lg transition-all <%= (locals.queryLimit == num) ? 'bg-primary-theme text-white shadow-md' : 'opacity-50 hover:opacity-100' %>">
                         <%= num %>
                     </button>
@@ -273,9 +297,13 @@
 
 <script src="/socket.io/socket.io.js"></script>
 <script>
+    let currentType = '<%= currentType %>';
+    let currentFormat = '<%= currentFormat %>';
     const filterInput = document.getElementById('filterInput');
     const locationInput = document.getElementById('locationInput');
-    let searchTimeout;
+    const genreInput = document.getElementById('genreInput');
+    const formatTermsInput = document.getElementById('format-multi-select');
+    let currentLimit = <%= locals.queryLimit %>;
 
     function updateURLParams(key, value) {
         const url = new URL(window.location.href);
@@ -291,8 +319,29 @@
         window.location.href = url.toString();
     }
 
-    function changeLimit(val) {
-        updateURLParams('limit', val);
+    function reloadPage(){
+        const url = new URL(window.location.origin + window.location.pathname);
+
+        validateAndSetUrlSearchParamString('type', currentType);
+        validateAndSetUrlSearchParamString('format', currentFormat);
+        validateAndSetUrlSearchParamString('search', filterInput?.value);
+        validateAndSetUrlSearchParamString('location', locationInput?.value);
+
+        if(currentType !== 'all') validateAndSetUrlSearchParamString('genre', genreInput?.value);
+        if(formatTermsInput && currentType && currentType == 'music'){
+            const checkedOptions = [...formatTermsInput.querySelectorAll('input[type="checkbox"]:checked')].map(cb => cb.value)
+            if(checkedOptions.length) url.searchParams.set('formatTerms', checkedOptions);
+        }
+        
+        validateAndSetUrlSearchParamString('limit', currentLimit);
+        url.searchParams.set('page', 1);
+        window.location.href = url.toString();
+
+        function validateAndSetUrlSearchParamString(key, value){
+            if (value === null || value === undefined || (typeof value === "string" && value.trim() === "")) return;
+            if((typeof value === "string")) value = value.trim();
+            url.searchParams.set(key, value);
+        }
     }
 
     function changePage(page) {
@@ -301,27 +350,13 @@
         window.location.href = url.toString();
     }
 
-    if (filterInput) {
-        filterInput.addEventListener('input', (e) => {
-            clearTimeout(searchTimeout);
-            searchTimeout = setTimeout(() => {
-                updateURLParams('search', e.target.value);
-            }, 500);
+    document.querySelectorAll('.filter-input-textbox').forEach(element => {
+        element.addEventListener('keydown', (e) => {
+            if(e.key !== 'Enter') return;
+            reloadPage();
         });
-    }
-
-    if (locationInput) {
-        locationInput.addEventListener('change', (e) => {
-            updateURLParams('location', e.target.value);
-        });
-    }
-
-    const genreInput = document.getElementById('genreInput');
-    if (genreInput) {
-        genreInput.addEventListener('change', (e) => {
-            updateURLParams('genre', e.target.value);
-        });
-    }
+    });
+    
 
     <% if (user.isAdmin) { %>
         const socket = io();


### PR DESCRIPTION
- Moved standard format terms to a constants file to be reused.
- Made it so the search text-box in all add-[item] pages is auto focused. (it was frustrating when constructing library and adding many items one after another)
- Implemented the search by format terms for music.
   - I moved the add and estimate button to make place for more filters. (and I didn't think they belonged next to the filters anyway)
   - Made it so we don't rely on the url to construct the filter.
   - Made it so we don't execute the search on a timer or on change anymore.
   - You now search when pressing enter, or pressing the search button.

I changed things that wasn't in MY taste. I'm very open to suggestions.