### PR TITLE
fix: resolve fetchEstimation ReferenceError caused by newlines in translation strings

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -376,6 +376,7 @@
     "confirm_delete": "Möchten Sie dieses Album wirklich aus Ihrer Sammlung löschen? \nDiese Aktion ist irreversibel.",
     "duration_label": "Dauer",
     "estimation_title": "Schätzung (Discogs)",
+    "for_sale": "zum Verkauf",
     "historical_estimate": "Historische Schätzung (VG)",
     "import_tracklist_btn": "Trackliste importieren",
     "importing": "Importieren...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -445,6 +445,7 @@
     "tracklist_title": "Tracklist",
     "no_tracks": "No tracklist available.",
     "market_price": "Current Market Price",
+    "for_sale": "for sale",
     "historical_estimate": "Historical Estimate (VG+)",
     "shipping_hint": "*Excl. shipping",
     "view_discogs": "View Discogs page",

--- a/locales/es.json
+++ b/locales/es.json
@@ -376,6 +376,7 @@
     "confirm_delete": "¿Estás seguro de que quieres eliminar este álbum de tu colección? \nEsta acción es irreversible.",
     "duration_label": "Duración",
     "estimation_title": "Estimación (Discogs)",
+    "for_sale": "a la venta",
     "historical_estimate": "Estimación histórica (VG)",
     "import_tracklist_btn": "Importar lista de canciones",
     "importing": "Importador...",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -445,6 +445,7 @@
     "tracklist_title": "Pistes",
     "no_tracks": "Aucune liste de pistes disponible.",
     "market_price": "Prix Marché Actuel",
+    "for_sale": "en vente",
     "historical_estimate": "Estimation Historique (VG+)",
     "shipping_hint": "*Hors frais de port",
     "view_discogs": "Voir fiche Discogs",

--- a/locales/it.json
+++ b/locales/it.json
@@ -376,6 +376,7 @@
     "confirm_delete": "Sei sicuro di voler eliminare questo album dalla tua raccolta? \nQuesta azione è irreversibile.",
     "duration_label": "Durata",
     "estimation_title": "Stima (Discogs)",
+    "for_sale": "in vendita",
     "historical_estimate": "Stima storica (VG)",
     "import_tracklist_btn": "Importa l'elenco delle tracce",
     "importing": "Importazione...",

--- a/routes/albumRoutes.js
+++ b/routes/albumRoutes.js
@@ -845,7 +845,7 @@ router.get('/api/estimate/:discogsId', requireAuth, async (req, res) => {
                         success: true,
                         source: 'market', // concrete market data
                         price: statsData.lowest_price,
-                        details: `${statsData.num_for_sale} for sale`
+                        details: `${statsData.num_for_sale} ${req.t('detail.for_sale')}`
                     });
                 }
             }

--- a/views/book-detail.ejs
+++ b/views/book-detail.ejs
@@ -281,13 +281,13 @@
     </div>
 
     <script>
-        const translations = {
-            official_cover: "<%= t('detail.official_cover') %>",
-            additional_image: "<%= t('detail.additional_image') %>",
-            confirm_delete: "<%= t('detail.confirm_delete') %>",
-            unavailable_data: "<%= t('detail.unavailable_data') %>",
-            error_server: "<%= t('messages.generic_error') %>"
-        };
+        const translations = <%- JSON.stringify({
+            official_cover: t('detail.official_cover'),
+            additional_image: t('detail.additional_image'),
+            confirm_delete: t('detail.confirm_delete'),
+            unavailable_data: t('detail.unavailable_data'),
+            error_server: t('messages.generic_error')
+        }) %>;
 
         async function confirmDelete(id) {
             if (confirm(translations.confirm_delete)) {

--- a/views/dvd-detail.ejs
+++ b/views/dvd-detail.ejs
@@ -284,10 +284,10 @@
     </div>
 
     <script>
-        const translations = {
-            confirm_delete: "<%= t('detail.confirm_delete') %>",
-            error_server: "<%= t('messages.generic_error') %>"
-        };
+        const translations = <%- JSON.stringify({
+            confirm_delete: t('detail.confirm_delete'),
+            error_server: t('messages.generic_error')
+        }) %>;
 
         async function confirmDelete(id) {
             if (confirm(translations.confirm_delete)) {

--- a/views/vinyl-detail.ejs
+++ b/views/vinyl-detail.ejs
@@ -368,18 +368,18 @@
     </div>
 
     <script>
-        const translations = {
-            official_cover: "<%= t('detail.official_cover') %>",
-            additional_image: "<%= t('detail.additional_image') %>",
-            confirm_delete: "<%= t('detail.confirm_delete') %>",
-            market_price: "<%= t('detail.market_price') %>",
-            historical_estimate: "<%= t('detail.historical_estimate') %>",
-            shipping_hint: "<%= t('detail.shipping_hint') %>",
-            view_discogs: "<%= t('detail.view_discogs') %>",
-            unavailable_data: "<%= t('detail.unavailable_data') %>",
-            analyzing: "<%= t('detail.market_analysis') %>",
-            error_server: "<%= t('messages.generic_error') %>"
-        };
+        const translations = <%- JSON.stringify({
+            official_cover: t('detail.official_cover'),
+            additional_image: t('detail.additional_image'),
+            confirm_delete: t('detail.confirm_delete'),
+            market_price: t('detail.market_price'),
+            historical_estimate: t('detail.historical_estimate'),
+            shipping_hint: t('detail.shipping_hint'),
+            view_discogs: t('detail.view_discogs'),
+            unavailable_data: t('detail.unavailable_data'),
+            analyzing: t('detail.market_analysis'),
+            error_server: t('messages.generic_error')
+        }) %>;
 
         const currentLocale = '<%= currentLng === "fr" ? "fr-FR" : "en-US" %>';
 


### PR DESCRIPTION
## Problem

In `vinyl-detail.ejs`, `book-detail.ejs`, and `dvd-detail.ejs`, translations were injected into JavaScript string literals using `<%= t('key') %>`. Some locale strings (e.g. Spanish `confirm_delete`, `shipping_hint`) contain literal newline characters, which break the JS syntax and silently kill the entire `<script>` block — making `fetchEstimation` undefined when the Calculate button is clicked.

## Fix

Replace manual string interpolation with `<%- JSON.stringify({...}) %>` to safely serialize all translation strings as a JS object, regardless of their content.

Also replaces the hardcoded English "for sale" string in the Discogs market stats response with a translatable key (`detail.for_sale`) across all 5 supported locales (en, fr, es, de, it).

## Testing

Tested with Spanish locale (which contains the problematic newlines). The Estimate button now works correctly.
