### PR TITLE
feat: manual vinyl entry, tracklist editor and total duration display

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -724,5 +724,11 @@
     "view_igdb": "Auf IGDB ansehen",
     "refresh_info_success": "Metadaten erfolgreich aktualisiert!",
     "refresh_info_error": "Fehler beim Aktualisieren der Metadaten."
+  },
+  "tracklist": {
+    "col_position": "Pos.",
+    "col_title": "Titel",
+    "col_duration": "Dauer",
+    "add_track": "Titel hinzufügen"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -42,7 +42,8 @@
     "scan_stop": "Stoppen Sie den Scanvorgang",
     "search_placeholder": "Künstler, Album...",
     "separator_or": "ODER",
-    "title": "Fügen Sie einen Datensatz hinzu"
+    "title": "Fügen Sie einen Datensatz hinzu",
+    "manual_entry": "Nicht auf Discogs? Manuell hinzufügen"
   },
   "admin": {
     "add_user_btn": "Benutzer hinzufügen",
@@ -365,7 +366,10 @@
     "barcode_locked": "Barcode sperren",
     "sleeve_condition_label": "Zustand der Hülle",
     "sleeve_condition_placeholder": "Zustand auswählen...",
-    "sleeve_condition_generic": "Generische Hülle"
+    "sleeve_condition_generic": "Generische Hülle",
+    "add_cover": "Titelbild hinzufügen",
+    "manual_title": "Album manuell hinzufügen",
+    "manual_mode_hint": "Manuelle Eingabe — keine Discogs-Daten. Marktschätzung nicht verfügbar."
   },
   "detail": {
     "added_at": "Hinzugefügt bei",

--- a/locales/en.json
+++ b/locales/en.json
@@ -724,5 +724,11 @@
     "view_igdb": "View on IGDB",
     "refresh_info_success": "Metadata refreshed successfully!",
     "refresh_info_error": "Error refreshing metadata."
+  },
+  "tracklist": {
+    "col_position": "Pos.",
+    "col_title": "Title",
+    "col_duration": "Dur.",
+    "add_track": "Add track"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -194,7 +194,8 @@
     "filter_ex_year": "Ex: 1994",
     "filter_ex_country": "Ex: France",
     "filter_ex_genre": "Ex: Electronic",
-    "filter_ex_label": "Ex: EMI"
+    "filter_ex_label": "Ex: EMI",
+    "manual_entry": "Not on Discogs? Add manually"
   },
   "admin": {
     "title": "Administration",
@@ -422,7 +423,10 @@
     "barcode_locked": "Lock barcode",
     "sleeve_condition_label": "Sleeve Condition",
     "sleeve_condition_placeholder": "Select sleeve condition...",
-    "sleeve_condition_generic": "Generic Sleeve"
+    "sleeve_condition_generic": "Generic Sleeve",
+    "add_cover": "Add cover",
+    "manual_title": "Add album manually",
+    "manual_mode_hint": "Manual entry — no Discogs data. Market estimation will not be available."
   },
   "edit_vinyl": {
     "title": "Edit Album",

--- a/locales/es.json
+++ b/locales/es.json
@@ -42,7 +42,8 @@
     "scan_stop": "Dejar de escanear",
     "search_placeholder": "Artista, Álbum...",
     "separator_or": "O",
-    "title": "Agregar un registro"
+    "title": "Agregar un registro",
+    "manual_entry": "No aparece en Discogs? Agregar manualmente"
   },
   "admin": {
     "add_user_btn": "Agregar usuario",
@@ -355,6 +356,9 @@
     "no_images": "No se encontraron imágenes.",
     "no_results": "No se encontraron imágenes.",
     "replace_cover": "Reemplace la cubierta principal",
+    "add_cover": "Agregar portada",
+    "manual_title": "Agregar álbum manualmente",
+    "manual_mode_hint": "Entrada manual — sin datos de Discogs. La estimación de mercado no estará disponible.",
     "search_hint": "Haga clic en la lupa para buscar.",
     "source_local": "Local",
     "source_search": "Buscar",

--- a/locales/es.json
+++ b/locales/es.json
@@ -724,5 +724,11 @@
     "view_igdb": "Ver en IGDB",
     "refresh_info_success": "¡Metadatos actualizados con éxito!",
     "refresh_info_error": "Error al actualizar los metadatos."
+  },
+  "tracklist": {
+    "col_position": "Pos.",
+    "col_title": "Título",
+    "col_duration": "Dur.",
+    "add_track": "Añadir pista"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -194,7 +194,8 @@
     "filter_ex_year": "Ex: 1994",
     "filter_ex_country": "Ex: France",
     "filter_ex_genre": "Ex: Electronic",
-    "filter_ex_label": "Ex: EMI"
+    "filter_ex_label": "Ex: EMI",
+    "manual_entry": "Introuvable sur Discogs ? Ajouter manuellement"
   },
   "admin": {
     "title": "Administration",
@@ -422,7 +423,10 @@
     "barcode_locked": "Verrouiller le code-barres",
     "sleeve_condition_label": "État de la pochette",
     "sleeve_condition_placeholder": "Sélectionner l'état...",
-    "sleeve_condition_generic": "Pochette générique"
+    "sleeve_condition_generic": "Pochette générique",
+    "add_cover": "Ajouter une pochette",
+    "manual_title": "Ajouter un album manuellement",
+    "manual_mode_hint": "Saisie manuelle — pas de données Discogs. L'estimation de marché ne sera pas disponible."
   },
   "edit_vinyl": {
     "title": "Modifier l'album",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -724,5 +724,11 @@
     "view_igdb": "Voir sur IGDB",
     "refresh_info_success": "Métadonnées actualisées avec succès !",
     "refresh_info_error": "Erreur lors de l'actualisation des métadonnées."
+  },
+  "tracklist": {
+    "col_position": "Pos.",
+    "col_title": "Titre",
+    "col_duration": "Durée",
+    "add_track": "Ajouter une piste"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -42,7 +42,8 @@
     "scan_stop": "Interrompi la scansione",
     "search_placeholder": "Artista, album...",
     "separator_or": "O",
-    "title": "Aggiungi un record"
+    "title": "Aggiungi un record",
+    "manual_entry": "Non su Discogs? Aggiungi manualmente"
   },
   "admin": {
     "add_user_btn": "Aggiungi utente",
@@ -365,7 +366,10 @@
     "barcode_locked": "Blocca il codice a barre",
     "sleeve_condition_label": "Condizione della copertina",
     "sleeve_condition_placeholder": "Seleziona condizione...",
-    "sleeve_condition_generic": "Copertina generica"
+    "sleeve_condition_generic": "Copertina generica",
+    "add_cover": "Aggiungi copertina",
+    "manual_title": "Aggiungi album manualmente",
+    "manual_mode_hint": "Inserimento manuale — nessun dato Discogs. La stima di mercato non sarà disponibile."
   },
   "detail": {
     "added_at": "Aggiunto a",

--- a/locales/it.json
+++ b/locales/it.json
@@ -724,5 +724,11 @@
     "view_igdb": "Vedi su IGDB",
     "refresh_info_success": "Metadati aggiornati con successo!",
     "refresh_info_error": "Errore durante aggiornamento metadati."
+  },
+  "tracklist": {
+    "col_position": "Pos.",
+    "col_title": "Titolo",
+    "col_duration": "Dur.",
+    "add_track": "Aggiungi traccia"
   }
 }

--- a/routes/albumRoutes.js
+++ b/routes/albumRoutes.js
@@ -377,6 +377,31 @@ router.get('/add-vinyl', requireAuth, requireAdmin, (req, res) => {
     res.render('add-vinyl', { searchType, searchQuery, currentType: 'add-vinyl' });
 });
 
+router.get('/add-vinyl/manual', requireAuth, requireAdmin, async (req, res) => {
+    try {
+        const adminId = await getAdminId();
+        const locations = await Item.distinct('location', { owner: adminId, location: { $ne: "" } });
+        const genres = await Item.distinct('genre', {
+            owner: adminId,
+            genre: { $ne: "" },
+            $or: [{ kind: 'Music' }, { kind: { $exists: false } }]
+        });
+
+        const vinyl = {
+            title: '', artist: '', year: '', label: '', catalog_number: '',
+            format_type: '', variant_color: '', tracklist: [], cover_image: '',
+            discogs_id: '', country: '', genres: [], styles: [], barcode: '',
+            media_type: 'vinyl', user_image: '', location: '', sleeve_condition: '',
+            is_bootleg: false
+        };
+
+        res.render('confirm-vinyl', { vinyl, user: res.locals.user, locations, genres, currentType: 'music', isManual: true });
+    } catch (err) {
+        console.error(err);
+        res.redirect('/add-vinyl');
+    }
+});
+
 // route for editing an existing album
 router.get('/album/edit/:id', requireAuth, async (req, res) => {
     try {

--- a/views/add-vinyl.ejs
+++ b/views/add-vinyl.ejs
@@ -121,6 +121,12 @@
             </div>
         </form>
 
+        <div class="max-w-2xl mx-auto mb-10 text-center">
+            <a href="<%= baseUrl %>/add-vinyl/manual" class="text-xs opacity-50 hover:opacity-100 transition-opacity inline-flex items-center gap-1.5">
+                <i class="fa-solid fa-pencil"></i> <%= t('add_vinyl.manual_entry') %>
+            </a>
+        </div>
+
         <% if (locals.results) { %>
             <div class="mb-4 flex items-center justify-between">
                 <h2 class="text-xl font-bold transition-colors">

--- a/views/confirm-vinyl.ejs
+++ b/views/confirm-vinyl.ejs
@@ -218,8 +218,9 @@
                     <input type="hidden" name="discogs_id" value="<%= vinyl.discogs_id %>">
                     <input type="hidden" name="label" value="<%= vinyl.label %>">
                     <input type="hidden" name="catalog_number" value="<%= vinyl.catalog_number %>">
-                    <input type="hidden" name="tracklist_json" value="<%= JSON.stringify(vinyl.tracklist) %>">
                     <input type="hidden" name="country" value="<%= vinyl.country %>">
+
+                    <%- include('partials/tracklist-editor') %>
 
                     <div class="mb-6">
                         <label class="block mb-3 text-sm font-bold uppercase tracking-widest opacity-60"><%= t('confirm_vinyl.field_media_type') %></label>

--- a/views/confirm-vinyl.ejs
+++ b/views/confirm-vinyl.ejs
@@ -6,6 +6,12 @@
             <i class="fa-solid fa-arrow-left mr-2"></i> <%= t('common.back_to_search') %>
         </a>
     </nav>
+    <% if (locals.isManual) { %>
+    <div class="mb-6 flex items-center gap-3 px-4 py-3 rounded-xl bg-black/5 dark:bg-white/5 text-sm">
+        <i class="fa-solid fa-pencil opacity-50"></i>
+        <span class="opacity-60"><%= t('confirm_vinyl.manual_mode_hint') %></span>
+    </div>
+    <% } %>
 
     <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <div class="lg:col-span-4 space-y-6">
@@ -61,7 +67,11 @@
         <div class="lg:col-span-8">
             <div class="card-theme rounded-xl p-6 md:p-8 transition-colors shadow-sm">
                 <h1 class="text-2xl font-bold mb-6 flex items-center gap-2">
+                    <% if (locals.isManual) { %>
+                    <i class="fa-solid fa-pencil text-primary-theme"></i> <%= t('confirm_vinyl.manual_title') %>
+                    <% } else { %>
                     <i class="fa-solid fa-pen-to-square text-primary-theme"></i> <%= t('confirm_vinyl.config_title') %>
+                    <% } %>
                 </h1>
 
                 <form action="<%= baseUrl %>/save-vinyl" method="POST" class="space-y-6">
@@ -109,15 +119,15 @@
 
                     <div class="space-y-4">
                         <div class="flex items-center">
-                            <input id="checkEditCover" type="checkbox" class="w-4 h-4 text-primary-theme bg-black/5 dark:bg-white/10 border-transparent rounded focus:ring-primary-theme focus:ring-2 cursor-pointer transition-colors">
+                            <input id="checkEditCover" type="checkbox" <%= locals.isManual ? 'checked' : '' %> class="w-4 h-4 text-primary-theme bg-black/5 dark:bg-white/10 border-transparent rounded focus:ring-primary-theme focus:ring-2 cursor-pointer transition-colors">
                             <label for="checkEditCover" class="ml-2 text-sm font-bold cursor-pointer opacity-80 hover:opacity-100 transition-opacity">
-                                <%= t('confirm_vinyl.replace_cover') %>
+                                <%= locals.isManual ? t('confirm_vinyl.add_cover') : t('confirm_vinyl.replace_cover') %>
                             </label>
                         </div>
 
                         <input type="hidden" name="cover_image" id="inputCoverImage" value="<%= vinyl.cover_image %>">
 
-                        <div id="boxEditCover" class="hidden p-4 card-theme rounded-2xl border border-black/10 dark:border-white/10 shadow-inner transition-all">
+                        <div id="boxEditCover" class="<%= locals.isManual ? '' : 'hidden' %> p-4 card-theme rounded-2xl border border-black/10 dark:border-white/10 shadow-inner transition-all">
                             <div class="flex gap-1 mb-6 p-1 bg-black/5 dark:bg-white/5 rounded-xl">
                                 <button type="button" onclick="setImgTab('cover', 'local')" id="tab-cover-local" class="flex-1 py-2 text-[10px] font-black uppercase tracking-widest rounded-lg transition-all bg-primary-theme text-white">
                                     <i class="fa-solid fa-upload mr-1"></i> <%= t('confirm_vinyl.source_local') %>

--- a/views/edit-vinyl.ejs
+++ b/views/edit-vinyl.ejs
@@ -245,9 +245,10 @@
                             </label>
                         </div>
                     </div>
+                    <%- include('partials/tracklist-editor') %>
                     <input type="hidden" name="in_wishlist" value="<%= vinyl.in_wishlist %>">
                     <input type="hidden" name="mongo_id" value="<%= vinyl._id %>">
-                    
+
                     <button type="submit" class="w-full text-white bg-primary-theme hover:brightness-110 font-bold rounded-xl text-lg px-5 py-4 transition-transform hover:scale-[1.01] flex items-center justify-center gap-2 shadow-lg shadow-primary-theme/20">
                         <i class="fa-solid fa-save"></i> <%= t('common.save_changes') %>
                     </button>

--- a/views/partials/tracklist-editor.ejs
+++ b/views/partials/tracklist-editor.ejs
@@ -68,6 +68,19 @@
         del.innerHTML = '<i class="fa-solid fa-xmark text-xs"></i>';
         del.addEventListener('click', () => { row.remove(); updateJson(); });
 
+        dur.addEventListener('blur', () => {
+            const v = dur.value.trim();
+            if (!v) return;
+            if (/^\d+$/.test(v)) {
+                dur.value = `${v}:00`;
+            } else if (/^\d+:\d$/.test(v)) {
+                dur.value = v.replace(/:(\d)$/, ':0$1');
+            } else if (!/^\d+:\d{2}$/.test(v)) {
+                dur.value = '';
+            }
+            updateJson();
+        });
+
         [pos, title, dur].forEach(inp => {
             row.appendChild(inp);
             inp.addEventListener('input', updateJson);

--- a/views/partials/tracklist-editor.ejs
+++ b/views/partials/tracklist-editor.ejs
@@ -1,0 +1,92 @@
+<div class="mt-6 border-t border-black/10 dark:border-white/10 pt-6">
+    <div class="flex items-center justify-between mb-3">
+        <h3 class="text-sm font-bold uppercase tracking-widest opacity-60 flex items-center gap-2">
+            <i class="fa-solid fa-music"></i> <%= t('confirm_vinyl.tracks_title') %>
+            <span id="tlCount" class="font-mono font-normal text-xs opacity-60"></span>
+        </h3>
+    </div>
+
+    <div class="mb-1 hidden md:grid grid-cols-[3.5rem_1fr_3.5rem_1.5rem] gap-2 px-1">
+        <span class="text-[10px] font-bold uppercase opacity-30"><%= t('tracklist.col_position') %></span>
+        <span class="text-[10px] font-bold uppercase opacity-30"><%= t('tracklist.col_title') %></span>
+        <span class="text-[10px] font-bold uppercase opacity-30 text-right"><%= t('tracklist.col_duration') %></span>
+        <span></span>
+    </div>
+
+    <div id="tlEditor" class="space-y-1.5"></div>
+
+    <button type="button" id="tlAddBtn"
+        class="mt-3 w-full py-2.5 text-xs font-bold opacity-30 hover:opacity-70 border-2 border-dashed border-current rounded-xl transition-all flex items-center justify-center gap-2">
+        <i class="fa-solid fa-plus"></i> <%= t('tracklist.add_track') %>
+    </button>
+
+    <input type="hidden" name="tracklist_json" id="tlJson" value="<%= JSON.stringify(vinyl.tracklist || []) %>">
+</div>
+
+<script>
+(function () {
+    const editor  = document.getElementById('tlEditor');
+    const jsonIn  = document.getElementById('tlJson');
+    const countEl = document.getElementById('tlCount');
+    const addBtn  = document.getElementById('tlAddBtn');
+
+    function updateJson() {
+        const tracks = Array.from(editor.querySelectorAll('.tl-row')).map(row => ({
+            position: row.querySelector('.tl-pos').value.trim(),
+            title:    row.querySelector('.tl-title').value.trim(),
+            duration: row.querySelector('.tl-dur').value.trim()
+        }));
+        jsonIn.value = JSON.stringify(tracks);
+        const n = tracks.filter(t => t.title).length;
+        countEl.textContent = n ? `(${n})` : '';
+    }
+
+    function makeRow(track) {
+        const row = document.createElement('div');
+        row.className = 'tl-row grid grid-cols-[3.5rem_1fr_3.5rem_1.5rem] gap-2 items-center group';
+
+        const base = 'bg-black/5 dark:bg-white/5 rounded-lg text-xs p-2 outline-none focus:ring-1 focus:ring-primary-theme w-full';
+
+        const pos = document.createElement('input');
+        pos.type = 'text'; pos.value = track.position || '';
+        pos.placeholder = 'A1';
+        pos.className = base + ' tl-pos font-mono';
+
+        const title = document.createElement('input');
+        title.type = 'text'; title.value = track.title || '';
+        title.placeholder = '...';
+        title.className = base + ' tl-title';
+
+        const dur = document.createElement('input');
+        dur.type = 'text'; dur.value = track.duration || '';
+        dur.placeholder = '0:00';
+        dur.className = base + ' tl-dur font-mono text-right';
+
+        const del = document.createElement('button');
+        del.type = 'button';
+        del.className = 'tl-del opacity-0 group-hover:opacity-40 hover:!opacity-100 hover:text-red-500 transition-all text-center';
+        del.innerHTML = '<i class="fa-solid fa-xmark text-xs"></i>';
+        del.addEventListener('click', () => { row.remove(); updateJson(); });
+
+        [pos, title, dur].forEach(inp => {
+            row.appendChild(inp);
+            inp.addEventListener('input', updateJson);
+        });
+        row.appendChild(del);
+        return row;
+    }
+
+    const initial = JSON.parse(jsonIn.value || '[]');
+    initial.forEach(t => editor.appendChild(makeRow(t)));
+    updateJson();
+
+    addBtn.addEventListener('click', () => {
+        const row = makeRow({});
+        editor.appendChild(row);
+        row.querySelector('.tl-title').focus();
+        updateJson();
+    });
+
+    document.querySelector('form').addEventListener('submit', updateJson, { capture: true });
+})();
+</script>

--- a/views/vinyl-detail.ejs
+++ b/views/vinyl-detail.ejs
@@ -76,12 +76,36 @@
                                 <%= badgeText %>
                             </span>
 
+                            <%
+                                let _totalSecs = 0;
+                                (album.tracklist || []).forEach(function(tr) {
+                                    if (tr.duration && /^\d+:\d{2}$/.test(tr.duration)) {
+                                        const p = tr.duration.split(':');
+                                        _totalSecs += parseInt(p[0]) * 60 + parseInt(p[1]);
+                                    }
+                                });
+                                let _durationLabel = '';
+                                if (_totalSecs > 0) {
+                                    const _h = Math.floor(_totalSecs / 3600);
+                                    const _m = Math.floor((_totalSecs % 3600) / 60);
+                                    const _s = _totalSecs % 60;
+                                    _durationLabel = _h > 0
+                                        ? `${_h}:${String(_m).padStart(2,'0')}:${String(_s).padStart(2,'0')}`
+                                        : `${_m}:${String(_s).padStart(2,'0')}`;
+                                }
+                            %>
                             <% if (album.year) { %>
                                 <span
                                     class="px-3 py-1 bg-black/5 dark:bg-white/10 border border-transparent rounded-full text-xs opacity-80 transition-colors">
                                     <%= album.year %>
                                 </span>
-                                <% } %>
+                            <% } %>
+                            <% if (_durationLabel) { %>
+                                <span class="px-3 py-1 bg-black/5 dark:bg-white/10 border border-transparent rounded-full text-xs opacity-80 transition-colors flex items-center gap-1.5">
+                                    <i class="fa-regular fa-clock opacity-60"></i>
+                                    <%= _durationLabel %>
+                                </span>
+                            <% } %>
                                     <span
                                         class="px-3 py-1 bg-black/5 dark:bg-white/10 border border-transparent rounded-full text-xs opacity-80 transition-colors">
                                         <%= album.format_type %>


### PR DESCRIPTION
## What this PR adds

This PR introduces three related quality-of-life features for the music collection:

### 1. Manual vinyl entry
Allows adding records that are not found on Discogs, without going through
the search flow.

- New route `GET /add-vinyl/manual` renders the confirmation form with empty
  fields and `isManual: true`
- A discreet link is shown below the Discogs search form
- In manual mode: cover panel opens by default, market estimation is hidden,
  and an info banner explains that Discogs features are unavailable
- Saves via the existing `POST /save-vinyl` — no backend changes to the
  save logic

### 2. Tracklist editor
An editable tracklist component available in both the confirmation form
(new imports and manual entries) and the edit form (any existing record).

- Add, reorder and delete tracks with position, title and duration fields
- Duration is normalized on blur: `5` → `5:00`, `2:3` → `2:03`,
  invalid text → cleared
- Track count shown next to the section header
- Implemented as a self-contained partial (`views/partials/tracklist-editor.ejs`)
  to avoid duplication

### 3. Total duration pill
The vinyl detail view now shows the total album duration calculated from
the tracklist, displayed as a pill alongside the year and other metadata.

- Pure EJS calculation, no backend changes needed
- Only shown when the tracklist contains at least one track with a valid
  duration
- Format: `M:SS` for albums under one hour, `H:MM:SS` for longer ones

## Locales
All five supported languages (`fr`, `en`, `es`, `it`, `de`) include the
new translation keys for the manual entry flow and tracklist editor.

## No breaking changes
All additions are backwards-compatible. Records without a tracklist are
unaffected.

<img width="1456" height="935" alt="imagen" src="https://github.com/user-attachments/assets/233937a7-6743-4fa7-b706-4a0ef56eba04" />

<img width="1456" height="935" alt="imagen" src="https://github.com/user-attachments/assets/23df8e70-3d77-43b7-99e5-db7d61991f7b" />
