### PR TITLE
Update .env.example for use with quadlets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-MONGODB_URL=mongodb://mongodb:27017/dvinyl # MongoDB connection URL (you can change if needed)
+# MongoDB connection URL (you can change if needed)
+MONGODB_URL=mongodb://mongodb:27017/dvinyl
 
 PASSJWT=SomeComplexPassword
 SESSION_SECRET=AnotherComplexSecret


### PR DESCRIPTION
<!-- Thanks for contributing to DVinyl! 🙌 Fill in the sections below so I can review quickly. -->

## What does this PR do?

Update .env.example so it is safe to use with podman quadlets.
The first line of the .env.example has a comment on the same line as a variable declaration. When running DVinyl as a podman quadlet, it interprets everything before the hash sign as the variable, *including the space between the URL and the hash*. As a result, DVinyl can't connect to MongoDB because the namespace is incorrect. This is fixed by placing the comment on a separate line in the .env file

## Related issue

<!-- Link an issue if there is one, e.g. Closes #123. Skip for tiny fixes. -->

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧩 New or updated plugin
- [ ] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🧹 Refactor or chore

## Checklist

- [ ] `make typecheck` passes
- [x] I tested my changes locally
- [ ] I updated the docs or translations if needed
- [x] My change is focused on a single thing

## Screenshots

<!-- If your change affects the UI, drop a before/after screenshot here. -->

## Anything else?

<!-- Notes, open questions, things you are unsure about. All welcome. -->
