### PR TITLE
feat: public read-only share links for collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docker-compose.override.yml
 .vscode/
 .claude/
 dist/
+CLAUDE.MD
+/graphify-out

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ read-only preview of a finished instance.
 - **SSO login (OIDC).** Optional single sign-on with providers like Authentik, Keycloak, Authelia
   or pocketID, with optional automatic account creation from an identity provider group.
 - **Private or shared.** Keep your collection to yourself or open it up for others to browse.
+- **Public share links.** Generate a read-only link or QR code so anyone can browse a collection
+  (or just part of it, e.g. only Vinyls) without an account.
 
 ## Built-in plugins
 
@@ -114,6 +116,7 @@ No Docker? No worries. Have a look at the other ways to install and run DVinyl i
 | [Docker deployment](./docs/docker.md) | Deploy with Docker Compose (recommended) |
 | [API keys](./docs/api-keys.md) | Get your Discogs, Hardcover, TMDB, IGDB and Rebrickable keys |
 | [Plugin development](./docs/plugin-development.md) | Build your own media type as a code plugin |
+| [Public share links](./docs/sharing.md) | Let anyone browse a collection (or part of it) read-only, no account needed |
 | [Wiki](https://github.com/Kyonew/DVinyl/wiki) | User guides and no-code tutorials |
 
 ## Tech stack

--- a/app.ts
+++ b/app.ts
@@ -36,6 +36,7 @@ import setupRoutes from './routes/setupRoutes.js';
 import pluginBuilderRoutes from './routes/pluginBuilderRoutes.js';
 import pluginAssetRoutes from './routes/pluginAssetRoutes.js';
 import authRoutes from './routes/authRoutes.js';
+import shareRoutes from './routes/shareRoutes.js';
 import adminRoutes from './routes/adminRoutes.js';
 import settingsRoutes from './routes/settingsRoutes.js';
 import backupRoutes from './routes/backupRoutes.js';
@@ -235,6 +236,7 @@ loadPlugins();
 // Route mounting
 app.use(BASE_URL + '/setup', setupRoutes);
 app.use(BASE_URL, authRoutes);
+app.use(BASE_URL, shareRoutes);
 app.use(BASE_URL + '/admin', adminRoutes);
 app.use(BASE_URL + '/settings', settingsRoutes);
 app.use(BASE_URL + '/create-plugin', pluginBuilderRoutes);

--- a/core/routes/collectionRoute.ts
+++ b/core/routes/collectionRoute.ts
@@ -4,8 +4,8 @@ import { registry } from '../registry';
 import Item from '../../models/Item';
 import Collection from '../../models/Collection';
 import User from '../../models/User';
-import { requireAuth } from '../../middleware/authMiddleware';
-import { applyVisibilityFilter, applyEnabledModulesFilter } from '../../utils/visibilityHelper';
+import { requireAuth, requireAuthOrShareView } from '../../middleware/authMiddleware';
+import { applyVisibilityFilter, applyEnabledModulesFilter, applyShareScopeFilter } from '../../utils/visibilityHelper';
 import { escapeRegExp } from '../helpers';
 import { generateUniqueSlug } from '../../utils/collectionHelpers';
 import { checkCollectionCreation } from '../../utils/instanceSettings';
@@ -44,7 +44,7 @@ router.get('/wishlist', requireAuth, async (req: any, res: any) => {
   }
 });
 
-router.get('/collection', requireAuth, async (req: any, res: any) => {
+router.get('/collection', requireAuthOrShareView, async (req: any, res: any) => {
   try {
     const activeCollectionId = res.locals.activeCollectionId;
     if (!activeCollectionId) {
@@ -85,7 +85,16 @@ router.get('/collection', requireAuth, async (req: any, res: any) => {
     let conditions: any[] = [];
     let scopeConditions: any[] = [];
 
-    const enabledPlugins = registry.getEnabled(settings);
+    // A scoped share link only ever browses the types it allowlists - narrow the
+    // plugin list up front so search fields, the type/format filters and the
+    // artist/genre/style lookups below all follow suit automatically.
+    const shareScope = res.locals.isShareView ? (res.locals.shareScope || []) : [];
+    const shareScopedPluginIds = shareScope.length > 0
+      ? new Set(shareScope.map((s: any) => s.pluginId))
+      : null;
+    const enabledPlugins = shareScopedPluginIds
+      ? registry.getEnabled(settings).filter(p => shareScopedPluginIds.has(p.id))
+      : registry.getEnabled(settings);
 
     // SEARCH QUERY
     if (trimmedSearch) {
@@ -233,6 +242,9 @@ router.get('/collection', requireAuth, async (req: any, res: any) => {
 
     applyVisibilityFilter(query, res.locals.isCollectionAdmin, settings);
     applyEnabledModulesFilter(query, settings);
+    if (res.locals.isShareView) {
+      applyShareScopeFilter(query, shareScope);
+    }
 
     const totalItems = await Item.countDocuments(query);
 
@@ -275,10 +287,16 @@ router.get('/collection', requireAuth, async (req: any, res: any) => {
     const filterMap: Record<string, { id: string; label: string }[]> = {};
     for (const plugin of enabledPlugins) {
       const customized = res.locals.registry.get(plugin.id) || plugin;
-      filterMap[plugin.id] = customized.formats.map((f: any) => ({
-        id: f.value,
-        label: req.t(f.label)
-      }));
+      const scopedFormats: string[] | null = shareScopedPluginIds
+        ? (shareScope.find((s: any) => s.pluginId === plugin.id)?.formats || [])
+        : null;
+      const allowedFormats = scopedFormats && scopedFormats.length > 0 ? new Set(scopedFormats) : null;
+      filterMap[plugin.id] = customized.formats
+        .filter((f: any) => !allowedFormats || allowedFormats.has(f.value))
+        .map((f: any) => ({
+          id: f.value,
+          label: req.t(f.label)
+        }));
     }
 
     // DYNAMIC ARTIST LIST

--- a/core/routes/itemRoutes.ts
+++ b/core/routes/itemRoutes.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 import { PluginDefinition } from '../types';
 import Item from '../../models/Item';
 import User from '../../models/User';
-import { requireAuth, requireCollectionRole } from '../../middleware/authMiddleware';
+import { requireAuth, requireAuthOrShareView, requireCollectionRole } from '../../middleware/authMiddleware';
 import { parseGenresAndStyles, isBarcodeQuery, lookupBarcodeTitle } from '../helpers';
 import { DEFAULT_PLACEHOLDER_IMAGE } from '../placeholderImage';
 import { getExtraFields, toFieldDefinitions } from '../pluginExtraFields';
@@ -432,7 +432,7 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
   });
 
   // GET /{prefix}/:id -> details view
-  router.get(`${plugin.routePrefix}/:id`, requireAuth, async (req: any, res: any) => {
+  router.get(`${plugin.routePrefix}/:id`, requireAuthOrShareView, async (req: any, res: any) => {
     try {
       if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
         return res.status(404).send(req.t('errors.not_found'));
@@ -440,6 +440,22 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
       const item = await Item.findOne({ _id: req.params.id, collection: res.locals.activeCollectionId });
       if (!item) {
         return res.status(404).send(req.t('errors.not_found'));
+      }
+
+      // A scoped share link must not leak an out-of-scope item by URL-guessing its id,
+      // even though the collection listing itself already excludes it from the query.
+      // The format value lives under `format` for most plugins but under `media_type`
+      // for music (legacy field name) - see utils/visibilityHelper.ts's same convention.
+      if (res.locals.isShareView) {
+        const scope = res.locals.shareScope || [];
+        if (scope.length > 0) {
+          const entry = scope.find((s: any) => s.pluginId === plugin.id);
+          const itemFormat = (item as any).format ?? (item as any).media_type;
+          const allowed = !!entry && (!entry.formats?.length || entry.formats.includes(itemFormat));
+          if (!allowed) {
+            return res.status(404).send(req.t('errors.not_found'));
+          }
+        }
       }
 
       const formatted = plugin.formatForView(item);

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1,0 +1,69 @@
+# 🔗 Public share links
+
+Let anyone browse a collection read-only with a link or a QR code - no account, no guest
+credentials to maintain. A common use: a QR code taped next to a shelf so visitors can scan it and
+browse what is there on their own phone.
+
+## What a share link can and cannot do
+
+A share link is **read-only**. Whoever opens it can browse the collection, search, filter and open
+an item's detail page - exactly like a `viewer` member would. It can never:
+
+- Add, edit, delete or refresh an item
+- See the admin panel, settings, backups or any other collection
+- Create an account or otherwise leave a trace
+
+A collection can have **several share links at once**, each independent. Disabling, regenerating
+or deleting one never touches the others.
+
+## Creating a link
+
+1. Open the collection's **Admin panel** and scroll to **Public share links**.
+2. Click **New share link**.
+3. Optionally name it (e.g. "Vinyls only") - the name is only shown to you, never to visitors.
+4. Optionally narrow what it shows: check specific types (Music, Books, Games...) and, within a
+   type, specific formats (e.g. only `CD` and `Vinyl`, leaving Cassette and Digital out). Leave
+   everything unchecked to share the whole collection.
+5. Click **Create link**.
+
+Each link gets its own URL and QR code, generated on your own instance - the link's token is never
+sent to a third-party QR service.
+
+## A few scoped-link examples
+
+- Only Vinyls: check **Music**, then check only **Vinyl** under it.
+- Only CDs: check **Music**, then check only **CD**.
+- Vinyls and CDs, but not Cassettes: check **Music**, then check **Vinyl** and **CD**.
+- A whole media type, any format: check **Music** and leave every format under it unchecked.
+
+> [!TIP]
+> Checking a format automatically checks its type for you. If you ever submit a format without a
+> type checked (say, with JavaScript disabled), the server still infers the type from the format,
+> so the selection is never silently dropped.
+
+## Managing an existing link
+
+Each link's card shows its QR code, its URL (with a copy button) and its scope, plus:
+
+- **Disable / Enable** - pauses the link without losing its URL/QR code. Re-enabling brings back
+  the exact same link.
+- **Regenerate** - mints a brand new token for that link. The old URL and QR code stop working
+  immediately; anyone who only had the old one loses access.
+- **Delete** - removes the link entirely.
+- Editing the checkboxes and clicking **Save changes** updates what that link shows, in place -
+  the URL and QR code stay the same.
+
+> [!WARNING]
+> A share link's token is the only thing protecting it - anyone who has the URL or scans the QR
+> code can browse what it exposes, for as long as it stays enabled. Regenerate or delete a link if
+> it was shared more widely than you intended.
+
+## Interaction with hidden items
+
+If the collection already hides specific items, genres or types from non-admin viewers (the
+**Visibility** settings), those stay hidden from share links too - a share link never sees more
+than a real `viewer` member would.
+
+---
+
+[← Back to the README](../README.md)

--- a/locales/en.json
+++ b/locales/en.json
@@ -131,7 +131,14 @@
     "delete_admin_error": "You cannot delete another instance administrator.",
     "reset_admin_error": "You cannot reset another instance administrator's password.",
     "error_collection_quota": "You have reached the maximum number of collections allowed.",
-    "error_collection_forbidden": "Creating a collection is not allowed on this instance."
+    "error_collection_forbidden": "Creating a collection is not allowed on this instance.",
+    "share_enabled": "Sharing enabled.",
+    "share_disabled": "Sharing disabled.",
+    "share_regenerated": "Share link regenerated - the old link no longer works.",
+    "share_scope_updated": "Shared content updated.",
+    "share_link_created": "Share link created.",
+    "share_link_deleted": "Share link deleted.",
+    "error_share": "Could not update sharing."
   },
   "media": {
     "vinyl": "Vinyl",
@@ -490,6 +497,24 @@
       "subtitle": "Export this collection (items + settings) or replace its content with a backup file.",
       "confirm_import": "Importing will REPLACE every item of this collection. Continue?"
     },
+    "sharing": {
+      "title": "Public share links",
+      "subtitle": "Let anyone browse this collection read-only with a link or QR code - no account needed. Editing, deleting and every other page stay off-limits. Create several links to share different parts of the collection separately, e.g. one for Vinyls and one for CDs.",
+      "untitled_link": "Untitled link",
+      "label_placeholder": "Name this link (optional) - e.g. \"Vinyls only\"",
+      "enable_btn": "Enable",
+      "disable_btn": "Disable",
+      "regenerate_btn": "Regenerate",
+      "delete_btn": "Delete",
+      "confirm_regenerate": "This invalidates the current link and QR code - anyone using the old one loses access. Continue?",
+      "confirm_delete": "Delete this share link? Anyone using it loses access immediately.",
+      "new_link_btn": "New share link",
+      "create_btn": "Create link",
+      "scope_title": "What's shared",
+      "scope_hint": "Pick specific types (and, within a type, specific formats) to limit what this link shows - e.g. only CDs, or CDs and Vinyls. Leave everything unchecked to share the whole collection.",
+      "scope_empty_hint": "Nothing checked = the whole collection is shared.",
+      "scope_save_btn": "Save changes"
+    },
     "libib": {
       "title_books": "Libib - Books",
       "title_music": "Libib - Music",
@@ -577,6 +602,7 @@
   },
   "collection": {
     "title": "My Collection",
+    "share_view_banner": "You're viewing a shared collection - read-only.",
     "filter_placeholder": "Filter...",
     "refresh_tooltip": "Refresh from Discogs",
     "refresh": "Refresh",
@@ -708,7 +734,8 @@
     "collections": "Collections",
     "instance": "Instance",
     "administration": "Administration",
-    "new_collection": "New collection"
+    "new_collection": "New collection",
+    "share_view": "Shared collection · read-only"
   },
   "footer": {
     "made_with": "Made with",
@@ -1024,6 +1051,10 @@
     "message": "You are not a member of any collection yet. Ask an administrator to add you to one - your access will appear here automatically.",
     "message_can_create": "You don't have a collection yet. Create your own to start adding items - you'll be its administrator.",
     "create_btn": "Create my collection"
+  },
+  "share_invalid": {
+    "title": "Link unavailable",
+    "message": "This share link is invalid or is no longer available. Ask the collection owner for a new one."
   },
   "create_plugin": {
     "title": "Plugin editor",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -131,7 +131,14 @@
     "delete_admin_error": "Impossible de supprimer un autre administrateur d'instance.",
     "reset_admin_error": "Impossible de réinitialiser le mot de passe d'un autre administrateur d'instance.",
     "error_collection_quota": "Vous avez atteint le nombre maximum de collections autorisé.",
-    "error_collection_forbidden": "La création de collection n'est pas autorisée sur cette instance."
+    "error_collection_forbidden": "La création de collection n'est pas autorisée sur cette instance.",
+    "share_enabled": "Partage activé.",
+    "share_disabled": "Partage désactivé.",
+    "share_regenerated": "Lien de partage régénéré - l'ancien lien ne fonctionne plus.",
+    "share_scope_updated": "Contenu partagé mis à jour.",
+    "share_link_created": "Lien de partage créé.",
+    "share_link_deleted": "Lien de partage supprimé.",
+    "error_share": "Impossible de mettre à jour le partage."
   },
   "media": {
     "vinyl": "Vinyle",
@@ -490,6 +497,24 @@
       "subtitle": "Exporter cette collection (items + réglages) ou remplacer son contenu par une sauvegarde.",
       "confirm_import": "L'import va REMPLACER tous les items de cette collection. Continuer ?"
     },
+    "sharing": {
+      "title": "Liens de partage publics",
+      "subtitle": "Laissez n'importe qui parcourir cette collection en lecture seule via un lien ou un QR code - aucun compte requis. Modification, suppression et toute autre page restent inaccessibles. Créez plusieurs liens pour partager séparément différentes parties de la collection, par ex. un pour les Vinyles et un pour les CDs.",
+      "untitled_link": "Lien sans nom",
+      "label_placeholder": "Nommer ce lien (optionnel) - ex. \"Vinyles uniquement\"",
+      "enable_btn": "Activer",
+      "disable_btn": "Désactiver",
+      "regenerate_btn": "Régénérer",
+      "delete_btn": "Supprimer",
+      "confirm_regenerate": "Ceci invalide le lien et le QR code actuels - toute personne utilisant l'ancien perdra l'accès. Continuer ?",
+      "confirm_delete": "Supprimer ce lien de partage ? Toute personne l'utilisant perdra l'accès immédiatement.",
+      "new_link_btn": "Nouveau lien de partage",
+      "create_btn": "Créer le lien",
+      "scope_title": "Contenu partagé",
+      "scope_hint": "Choisissez des types (et, au sein d'un type, des formats) précis pour limiter ce que montre ce lien - par ex. seulement les CDs, ou CDs et Vinyles. Ne rien cocher partage toute la collection.",
+      "scope_empty_hint": "Rien de coché = toute la collection est partagée.",
+      "scope_save_btn": "Enregistrer les modifications"
+    },
     "libib": {
       "title_books": "Libib - Livres",
       "title_music": "Libib - Musique",
@@ -577,6 +602,7 @@
   },
   "collection": {
     "title": "Ma Collection",
+    "share_view_banner": "Vous consultez une collection partagée - lecture seule.",
     "filter_placeholder": "Filtrer...",
     "refresh_tooltip": "Rafraîchir depuis Discogs",
     "refresh": "Rafraîchir",
@@ -708,7 +734,8 @@
     "collections": "Collections",
     "instance": "Instance",
     "administration": "Administration",
-    "new_collection": "Nouvelle collection"
+    "new_collection": "Nouvelle collection",
+    "share_view": "Collection partagée · lecture seule"
   },
   "footer": {
     "made_with": "Développé avec",
@@ -1024,6 +1051,10 @@
     "message": "Vous n'avez accès à aucune collection pour le moment. Demandez à un administrateur de vous ajouter à l'une d'elles - votre accès apparaîtra ici automatiquement.",
     "message_can_create": "Vous n'avez encore aucune collection. Créez la vôtre pour commencer à ajouter vos items - vous en serez l'administrateur.",
     "create_btn": "Créer ma collection"
+  },
+  "share_invalid": {
+    "title": "Lien indisponible",
+    "message": "Ce lien de partage est invalide ou n'est plus disponible. Demandez un nouveau lien au propriétaire de la collection."
   },
   "create_plugin": {
     "title": "Éditeur de plugins",

--- a/middleware/authMiddleware.ts
+++ b/middleware/authMiddleware.ts
@@ -33,6 +33,19 @@ export const requireAuth = async (req: Record<string, any>, res: any, next: any)
 };
 
 
+/**
+ * Gates a read-only route reachable either by a signed-in member or by a valid
+ * collection share link (res.locals.isShareView, set by collectionMiddleware).
+ * Only ever use this on side-effect-free GET handlers - it does not enforce role,
+ * requireCollectionRole does that everywhere else, and a share visitor's
+ * collectionRole is always forced to 'viewer'.
+ */
+export const requireAuthOrShareView = (req: any, res: any, next: any) => {
+  if (req.user) return next();
+  if (res.locals.isShareView) return next();
+  return res.redirect('/login');
+};
+
 export const checkUser = (req: Record<string, any>, res: any, next: any) => {
 
   const token = req.cookies.jwt;

--- a/middleware/collectionMiddleware.ts
+++ b/middleware/collectionMiddleware.ts
@@ -14,9 +14,16 @@ import { canUserCreateCollection } from '../utils/instanceSettings';
  *   - res.locals.canCreateCollection: instance admin, or the instance allows it and the
  *                                     user is under their quota (drives the "new collection" UI)
  *   - req.activeCollectionId        : same id, for route handlers
+ *   - res.locals.isShareView        : true when access comes from one of a collection's
+ *                                     public share links (see routes/shareRoutes.ts)
+ *                                     rather than a real signed-in member
+ *   - res.locals.shareScope         : that link's scope (see models/Collection.ts
+ *                                     `shareLinks`) - empty array means the whole
+ *                                     collection; only meaningful when isShareView
  *
  * Self-heals: if the persisted lastActiveCollectionId is stale/missing, it resolves a
- * valid one and persists it back. No-ops for anonymous requests.
+ * valid one and persists it back. For anonymous requests, falls back to a share-link
+ * cookie if present; otherwise no-ops.
  */
 async function collectionMiddleware(req: any, res: any, next: any) {
     res.locals.activeCollectionId = null;
@@ -26,8 +33,34 @@ async function collectionMiddleware(req: any, res: any, next: any) {
     res.locals.isCollectionAdmin = false;
     res.locals.canEditCollection = false;
     res.locals.canCreateCollection = false;
+    res.locals.isShareView = false;
+    res.locals.shareScope = [];
 
     if (!req.user) {
+        // No session at all: the only other way in is one of a collection's public
+        // share links. Skip the lookup entirely when the cookie is absent, so ordinary
+        // anonymous traffic (the login page, static-ish routes) costs no extra query.
+        const shareToken = req.cookies?.dv_share;
+        if (shareToken) {
+            try {
+                const shared = await Collection.findOne({
+                    shareLinks: { $elemMatch: { token: shareToken, enabled: true } }
+                });
+                const link = shared?.shareLinks.find((l: any) => l.token === shareToken);
+                if (shared && link) {
+                    res.locals.activeCollectionId = shared._id;
+                    res.locals.activeCollection = shared;
+                    res.locals.collectionRole = 'viewer';
+                    res.locals.isCollectionAdmin = false;
+                    res.locals.canEditCollection = false;
+                    res.locals.isShareView = true;
+                    res.locals.shareScope = link.scope || [];
+                    req.activeCollectionId = shared._id;
+                }
+            } catch (err) {
+                console.error('[ERR] CollectionMiddleware (share):', err);
+            }
+        }
         return next();
     }
 

--- a/models/Collection.ts
+++ b/models/Collection.ts
@@ -40,8 +40,37 @@ const collectionSchema = new mongoose.Schema({
     members: {
         type: [memberSchema],
         default: []
+    },
+    // Public, account-free read-only browsing (see routes/shareRoutes.ts and
+    // middleware/collectionMiddleware.ts). A collection can have several independent
+    // links at once (e.g. one scoped to Vinyls, another to CDs) - each with its own
+    // token, so disabling/regenerating/deleting one never touches the others.
+    shareLinks: {
+        type: [{
+            token: { type: String, required: true },
+            // Optional friendly name shown in the admin ("Vinyls only"). Purely
+            // cosmetic - never rendered to a share visitor.
+            label: { type: String, default: '' },
+            enabled: { type: Boolean, default: true },
+            // Restricts this link to specific plugin types and, within a type, to
+            // specific format values (e.g. music -> only 'cd' and 'vinyl'). Empty
+            // array = whole collection, every type and format. An entry with an
+            // empty `formats` means every format of that one type.
+            scope: {
+                type: [{
+                    pluginId: { type: String, required: true },
+                    formats: { type: [String], default: [] }
+                }],
+                default: []
+            }
+        }],
+        default: []
     }
 }, { timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' } });
+
+// Multikey unique index: no two links, even across different collections, can ever
+// share a token. Sparse so a collection with zero links (empty array) is unaffected.
+collectionSchema.index({ 'shareLinks.token': 1 }, { unique: true, sparse: true });
 
 const Collection = mongoose.model('Collection', collectionSchema);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvinyl",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dvinyl",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
@@ -20,6 +20,7 @@
         "mongoose": "^8.14.1",
         "multer": "^2.1.1",
         "openid-client": "^6.8.4",
+        "qrcode": "^1.5.4",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -30,6 +31,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^2.1.0",
         "@types/node": "^25.9.3",
+        "@types/qrcode": "^1.5.6",
         "autoprefixer": "^10.4.21",
         "nodemon": "^3.1.10",
         "postcss": "^8.5.3",
@@ -695,6 +697,16 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -774,6 +786,30 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -1061,6 +1097,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001765",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
@@ -1115,6 +1160,35 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -1236,6 +1310,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -1259,6 +1342,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1655,6 +1744,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1762,25 +1864,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2184,6 +2274,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lodash.includes": {
@@ -2731,6 +2833,42 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2738,6 +2876,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2776,6 +2923,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2841,6 +2997,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -2917,6 +3090,21 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -3312,16 +3500,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3582,6 +3761,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -3591,10 +3776,30 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
     "node_modules/yallist": {
@@ -3602,6 +3807,41 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mongoose": "^8.14.1",
     "multer": "^2.1.1",
     "openid-client": "^6.8.4",
+    "qrcode": "^1.5.4",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.9.3",
+    "@types/qrcode": "^1.5.6",
     "autoprefixer": "^10.4.21",
     "nodemon": "^3.1.10",
     "postcss": "^8.5.3",

--- a/routes/adminRoutes.ts
+++ b/routes/adminRoutes.ts
@@ -1,13 +1,15 @@
 import express from "express";
 import mongoose from "mongoose";
 import bcrypt from "bcrypt";
+import QRCode from "qrcode";
 import User from "../models/User";
 import BlockedIP from "../models/blockedIP";
 import LoginLog from "../models/LoginLog";
 import Settings from "../models/Settings";
 import Collection from "../models/Collection";
 import { requireAuth, requireAdmin, requireCollectionRole } from "../middleware/authMiddleware";
-import { generateUniqueSlug } from "../utils/collectionHelpers";
+import { generateUniqueSlug, generateShareToken } from "../utils/collectionHelpers";
+import { BASE_URL } from "../config/constants";
 import { getInstanceSettings, saveInstanceSettings, InstanceSettingsData } from "../utils/instanceSettings";
 import PRESETS from "../config/themes";
 import Item from "../models/Item";
@@ -149,6 +151,9 @@ router.get("/", requireAuth, requireCollectionRole("admin"), async (req: any, re
       user: res.locals.user,
       successMessage: msgKey ? req.t(`messages.${msgKey}`) : null,
       newPassword: null,
+      // Share links must show a full, absolute URL (scheme + host) - a bare
+      // baseUrl-relative path is not something you can scan/paste elsewhere.
+      siteOrigin: `${req.protocol}://${req.get("host")}`,
     });
   } catch (err) {
     console.error(err);
@@ -580,6 +585,152 @@ router.post("/members/reset-password", requireAuth, requireCollectionRole("admin
   } catch (err) {
     console.error("Member reset error:", err);
     res.redirect("/admin?msg=error_member");
+  }
+});
+
+// ============ COLLECTION SHARING (collection-admin scope) ============
+// Public, account-free read-only browsing via routes/shareRoutes.ts. A collection can
+// have several independent links at once (e.g. one scoped to Vinyls, one to CDs) -
+// each with its own token, so disabling/regenerating/deleting one never touches
+// the others.
+
+/**
+ * Builds a shareLinks[].scope array from a create/edit submission. Checking no type
+ * boxes at all means "whole collection" - there is no separate on/off toggle for
+ * scope itself. A format checked without its type box (e.g. JS failed to auto-check
+ * it - see the checkbox script in views/admin.ejs) still counts: the type is implied
+ * by having any format selected under it, so a submission is never silently dropped.
+ */
+function parseShareScope(body: any): { pluginId: string; formats: string[] }[] {
+  const rawTypes = body.scopeTypes;
+  const checkedTypes: string[] = Array.isArray(rawTypes) ? rawTypes : rawTypes ? [rawTypes] : [];
+
+  const impliedTypes = Object.keys(body)
+    .filter((k) => k.startsWith("scopeFormats_"))
+    .filter((k) => (Array.isArray(body[k]) ? body[k].length > 0 : !!body[k]))
+    .map((k) => k.slice("scopeFormats_".length));
+
+  const selectedTypes = [...new Set([...checkedTypes, ...impliedTypes])];
+
+  return selectedTypes
+    .map((id: string) => {
+      const plugin = registry.get(id);
+      if (!plugin) return null;
+
+      const rawFormats = body[`scopeFormats_${id}`];
+      const submitted: string[] = Array.isArray(rawFormats) ? rawFormats : rawFormats ? [rawFormats] : [];
+      const validFormats = new Set((plugin.formats || []).map((f: any) => f.value));
+      const formats = submitted.filter((f: string) => validFormats.has(f));
+
+      return { pluginId: id, formats };
+    })
+    .filter((entry): entry is { pluginId: string; formats: string[] } => !!entry);
+}
+
+// Create a new share link with the submitted scope (and optional label).
+router.post("/share/create", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    const label = String(req.body.label || "").trim().slice(0, 60);
+    const scope = parseShareScope(req.body);
+
+    await Collection.updateOne(
+      { _id: res.locals.activeCollectionId },
+      { $push: { shareLinks: { token: generateShareToken(), label, enabled: true, scope } } },
+    );
+    res.redirect("/admin?msg=share_link_created");
+  } catch (err) {
+    console.error("Share create error:", err);
+    res.redirect("/admin?msg=error_share");
+  }
+});
+
+// Flip one link's enabled state (disabling keeps its token - re-enabling reuses the
+// same link/QR code instead of forcing a reprint).
+router.post("/share/:token/toggle", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    const coll: any = await Collection.findOne(
+      { _id: res.locals.activeCollectionId, "shareLinks.token": req.params.token },
+      { "shareLinks.$": 1 },
+    );
+    const link = coll?.shareLinks?.[0];
+    if (!link) return res.redirect("/admin?msg=error_share");
+
+    await Collection.updateOne(
+      { _id: res.locals.activeCollectionId, "shareLinks.token": req.params.token },
+      { $set: { "shareLinks.$.enabled": !link.enabled } },
+    );
+    res.redirect(`/admin?msg=${link.enabled ? "share_disabled" : "share_enabled"}`);
+  } catch (err) {
+    console.error("Share toggle error:", err);
+    res.redirect("/admin?msg=error_share");
+  }
+});
+
+// Update an existing link's scope and/or label in place.
+router.post("/share/:token/scope", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    const label = String(req.body.label || "").trim().slice(0, 60);
+    const scope = parseShareScope(req.body);
+
+    const result = await Collection.updateOne(
+      { _id: res.locals.activeCollectionId, "shareLinks.token": req.params.token },
+      { $set: { "shareLinks.$.scope": scope, "shareLinks.$.label": label } },
+    );
+    if (result.matchedCount === 0) return res.redirect("/admin?msg=error_share");
+    res.redirect("/admin?msg=share_scope_updated");
+  } catch (err) {
+    console.error("Share scope error:", err);
+    res.redirect("/admin?msg=error_share");
+  }
+});
+
+// Rotate a link's token - instantly invalidates whatever URL/QR code is already out
+// there, without touching this collection's other links.
+router.post("/share/:token/regenerate", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    const result = await Collection.updateOne(
+      { _id: res.locals.activeCollectionId, "shareLinks.token": req.params.token },
+      { $set: { "shareLinks.$.token": generateShareToken(), "shareLinks.$.enabled": true } },
+    );
+    if (result.matchedCount === 0) return res.redirect("/admin?msg=error_share");
+    res.redirect("/admin?msg=share_regenerated");
+  } catch (err) {
+    console.error("Share regenerate error:", err);
+    res.redirect("/admin?msg=error_share");
+  }
+});
+
+// Remove a link entirely.
+router.post("/share/:token/delete", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    await Collection.updateOne(
+      { _id: res.locals.activeCollectionId },
+      { $pull: { shareLinks: { token: req.params.token } } },
+    );
+    res.redirect("/admin?msg=share_link_deleted");
+  } catch (err) {
+    console.error("Share delete error:", err);
+    res.redirect("/admin?msg=error_share");
+  }
+});
+
+// Server-rendered QR PNG so a link's token never has to be handed to a
+// third-party QR-image API - it stays entirely within this instance.
+router.get("/share/:token/qr.png", requireAuth, requireCollectionRole("admin"), async (req: any, res: any) => {
+  try {
+    const coll = await Collection.findOne(
+      { _id: res.locals.activeCollectionId, "shareLinks.token": req.params.token, "shareLinks.enabled": true },
+      { _id: 1 },
+    );
+    if (!coll) return res.status(404).send(req.t("errors.not_found"));
+
+    const url = `${req.protocol}://${req.get("host")}${BASE_URL}/share/${req.params.token}`;
+    const png = await QRCode.toBuffer(url, { type: "png", width: 320, margin: 1 });
+    res.set("Content-Type", "image/png");
+    res.send(png);
+  } catch (err) {
+    console.error("Share QR error:", err);
+    res.status(500).send(req.t("errors.generic_server_error"));
   }
 });
 

--- a/routes/shareRoutes.ts
+++ b/routes/shareRoutes.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import Collection from '../models/Collection';
+
+/**
+ * Public, account-free entry point for a collection's share link (see
+ * routes/adminRoutes.ts for how the link/token is managed, and
+ * middleware/collectionMiddleware.ts for how the resulting cookie grants
+ * read-only access on every later request).
+ */
+const router = Router();
+
+router.get('/share/:token', async (req: any, res: any) => {
+  try {
+    const collection = await Collection.findOne({
+      shareLinks: { $elemMatch: { token: req.params.token, enabled: true } }
+    }).select('_id').lean();
+
+    if (!collection) {
+      // Same response whether the token never existed or was disabled/regenerated,
+      // so a stale link never reveals which case it is.
+      return res.status(404).render('share-invalid');
+    }
+
+    // The token itself is the credential, re-validated against the live Collection
+    // document on every request (collectionMiddleware), so it does not need to be
+    // cryptographically signed - unlike it, this cookie only has to survive tampering
+    // that a plain equality check on the DB row already catches.
+    res.cookie('dv_share', req.params.token, {
+      httpOnly: true,
+      maxAge: 180 * 24 * 60 * 60 * 1000,
+      secure: process.env.PROD === 'true',
+      sameSite: 'lax'
+    });
+
+    res.redirect('/collection');
+  } catch (err: any) {
+    console.error('[ERR] Share link:', err.message);
+    res.status(500).render('share-invalid');
+  }
+});
+
+export = router;

--- a/utils/collectionHelpers.ts
+++ b/utils/collectionHelpers.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import Collection from '../models/Collection';
 import User from '../models/User';
 
@@ -15,6 +16,14 @@ export function slugify(text: string): string {
         .trim()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Random, unguessable token for a collection's public share link
+ * (see routes/shareRoutes.ts). 160 bits, hex-encoded so it's plain URL-safe text.
+ */
+export function generateShareToken(): string {
+    return crypto.randomBytes(20).toString('hex');
 }
 
 /**

--- a/utils/visibilityHelper.ts
+++ b/utils/visibilityHelper.ts
@@ -28,6 +28,53 @@ export function applyEnabledModulesFilter(query: any, settings: any): void {
     query.$and.push(condition);
 }
 
+export interface ShareScopeEntry {
+    pluginId: string;
+    formats?: string[];
+}
+
+/**
+ * Restricts a query to a collection share link's scope (see models/Collection.ts
+ * `shareScope`). Only ever call this for an actual share view - a real member
+ * browsing their own collection must never be scoped by it.
+ * Empty/absent scope = whole collection, unrestricted (the default). A non-empty
+ * scope allowlists only the listed plugin types, each optionally narrowed to
+ * specific format values; an entry with no formats means every format of that type.
+ * A scope that resolves to nothing valid (e.g. every selected plugin was since
+ * removed) fails closed - matches no item - rather than falling back to "everything".
+ */
+export function applyShareScopeFilter(query: any, shareScope: ShareScopeEntry[] | undefined | null): void {
+    if (!shareScope || shareScope.length === 0) {
+        return;
+    }
+
+    const ors: any[] = [];
+    for (const entry of shareScope) {
+        const plugin = registry.get(entry.pluginId);
+        if (!plugin) continue; // plugin removed/renamed since the scope was saved
+
+        const kindMatch = plugin.matchesLegacyItems
+            ? { $or: [{ kind: plugin.kind }, { kind: { $exists: false } }] }
+            : { kind: plugin.kind };
+
+        // The format value lives under `format` for most plugins but under
+        // `media_type` for music (legacy field name) - same convention the generic
+        // format filter above (FORMAT FILTER) already checks both for. $and (not a
+        // spread) because kindMatch is itself an `$or` for matchesLegacyItems plugins
+        // (music) - spreading two `$or` keys into one object would silently drop one.
+        ors.push(entry.formats && entry.formats.length > 0
+            ? { $and: [kindMatch, { $or: [{ format: { $in: entry.formats } }, { media_type: { $in: entry.formats } }] }] }
+            : kindMatch);
+    }
+
+    const condition = ors.length > 0 ? { $or: ors } : { _id: null };
+
+    if (!query.$and) {
+        query.$and = [];
+    }
+    query.$and.push(condition);
+}
+
 interface VisibilitySettings {
     applyToAdmin: boolean;
     hiddenItems?: string[];

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -377,6 +377,111 @@
                                 </label>
                             </div>
                         </div>
+
+                        <div class="border-t border-black/5 dark:border-white/5 pt-6">
+                            <h3 class="text-lg font-bold flex items-center gap-2 mb-1">
+                                <i class="fa-solid fa-qrcode text-primary-theme"></i>
+                                <%= t('admin.sharing.title') %>
+                            </h3>
+                            <p class="text-xs opacity-60 max-w-md mb-4">
+                                <%= t('admin.sharing.subtitle') %>
+                            </p>
+
+                            <%
+                                const shareLinks = (locals.collectionDoc && collectionDoc.shareLinks) || [];
+                                const sharePlugins = registry.getAll().filter(p => settings.modules && settings.modules[p.collectionType] === true);
+                            %>
+
+                            <div class="space-y-4">
+                                <% shareLinks.forEach((link, idx) => { %>
+                                    <%
+                                        const scopeByType = {};
+                                        (link.scope || []).forEach((s) => { scopeByType[s.pluginId] = s.formats || []; });
+                                        const idPrefix = 'link' + idx;
+                                    %>
+                                    <div class="rounded-2xl bg-black/5 dark:bg-white/5 p-4 space-y-4">
+                                        <div class="flex flex-wrap items-center justify-between gap-3">
+                                            <div class="flex items-center gap-2 min-w-0">
+                                                <span class="w-2 h-2 rounded-full <%= link.enabled ? 'bg-green-500' : 'bg-gray-400' %> shrink-0"></span>
+                                                <span class="text-sm font-bold truncate"><%= link.label || t('admin.sharing.untitled_link') %></span>
+                                            </div>
+                                            <div class="flex flex-wrap gap-2">
+                                                <form action="<%= baseUrl %>/admin/share/<%= link.token %>/toggle" method="POST">
+                                                    <button type="submit"
+                                                        class="bg-black/5 dark:bg-white/10 hover:bg-<%= link.enabled ? 'red' : 'green' %>-500 hover:text-white px-3 py-1.5 rounded-lg text-xs font-bold transition-all">
+                                                        <%= link.enabled ? t('admin.sharing.disable_btn') : t('admin.sharing.enable_btn') %>
+                                                    </button>
+                                                </form>
+                                                <form action="<%= baseUrl %>/admin/share/<%= link.token %>/regenerate" method="POST"
+                                                    onsubmit="return confirm(<%= JSON.stringify(t('admin.sharing.confirm_regenerate')) %>)">
+                                                    <button type="submit" title="<%= t('admin.sharing.regenerate_btn') %>"
+                                                        class="bg-black/5 dark:bg-white/10 hover:bg-amber-500 hover:text-white w-8 h-8 rounded-lg text-xs transition-all">
+                                                        <i class="fa-solid fa-rotate"></i>
+                                                    </button>
+                                                </form>
+                                                <form action="<%= baseUrl %>/admin/share/<%= link.token %>/delete" method="POST"
+                                                    onsubmit="return confirm(<%= JSON.stringify(t('admin.sharing.confirm_delete')) %>)">
+                                                    <button type="submit" title="<%= t('admin.sharing.delete_btn') %>"
+                                                        class="bg-black/5 dark:bg-white/10 hover:bg-red-600 hover:text-white w-8 h-8 rounded-lg text-xs transition-all">
+                                                        <i class="fa-solid fa-trash"></i>
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        </div>
+
+                                        <% if (link.enabled) { %>
+                                            <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+                                                <img src="<%= baseUrl %>/admin/share/<%= link.token %>/qr.png" alt="QR code"
+                                                    class="w-24 h-24 rounded-xl border border-black/10 dark:border-white/10 bg-white p-2 shrink-0">
+                                                <div class="flex-1 min-w-0 flex items-center gap-2">
+                                                    <input type="text" readonly id="shareLinkInput_<%= idPrefix %>"
+                                                        value="<%= locals.siteOrigin || '' %><%= baseUrl %>/share/<%= link.token %>"
+                                                        class="flex-1 min-w-0 bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-xl px-3 py-2 text-xs font-mono outline-none">
+                                                    <button type="button"
+                                                        onclick="navigator.clipboard.writeText(document.getElementById('shareLinkInput_<%= idPrefix %>').value)"
+                                                        class="shrink-0 bg-black/5 dark:bg-white/5 hover:bg-primary-theme hover:text-white w-9 h-9 rounded-xl text-xs transition-all">
+                                                        <i class="fa-solid fa-copy"></i>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        <% } %>
+
+                                        <form action="<%= baseUrl %>/admin/share/<%= link.token %>/scope" method="POST"
+                                            class="space-y-3 pt-3 border-t border-black/5 dark:border-white/10">
+                                            <input type="text" name="label" maxlength="60" value="<%= link.label || '' %>"
+                                                placeholder="<%= t('admin.sharing.label_placeholder') %>"
+                                                class="w-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-xl px-3 py-2 text-xs outline-none focus:border-primary-theme">
+                                            <%- include('partials/share-scope-picker', { sharePlugins, scopeByType, idPrefix }) %>
+                                            <button type="submit"
+                                                class="bg-black/5 dark:bg-white/5 hover:bg-primary-theme hover:text-white px-4 py-2 rounded-xl text-xs font-black transition-all">
+                                                <%= t('admin.sharing.scope_save_btn') %>
+                                            </button>
+                                        </form>
+                                    </div>
+                                <% }) %>
+                            </div>
+
+                            <div class="mt-4">
+                                <button type="button" data-toggle-new-share-link
+                                    class="bg-primary-theme hover:brightness-110 text-white px-5 py-2.5 rounded-xl text-xs font-black transition-all flex items-center gap-2">
+                                    <i class="fa-solid fa-plus"></i>
+                                    <%= t('admin.sharing.new_link_btn') %>
+                                </button>
+
+                                <div id="newShareLinkForm" class="hidden mt-4 rounded-2xl bg-black/5 dark:bg-white/5 p-4">
+                                    <form action="<%= baseUrl %>/admin/share/create" method="POST" class="space-y-3">
+                                        <input type="text" name="label" maxlength="60"
+                                            placeholder="<%= t('admin.sharing.label_placeholder') %>"
+                                            class="w-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-xl px-3 py-2 text-xs outline-none focus:border-primary-theme">
+                                        <%- include('partials/share-scope-picker', { sharePlugins, scopeByType: {}, idPrefix: 'new' }) %>
+                                        <button type="submit"
+                                            class="bg-primary-theme hover:brightness-110 text-white px-5 py-2.5 rounded-xl text-xs font-black transition-all">
+                                            <%= t('admin.sharing.create_btn') %>
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </section>
 
@@ -574,6 +679,26 @@
                 const modal = document.getElementById(id);
                 modal.classList.toggle('hidden');
                 document.body.style.overflow = modal.classList.contains('hidden') ? 'auto' : 'hidden';
+            }
+
+            // Share scope pickers: checking a format under a type also checks that
+            // type's own box - a format checked alone has nowhere to be saved (the
+            // server only reads formats for a type it was told is in scope).
+            document.addEventListener('change', (e) => {
+                const target = e.target;
+                if (target.matches('input[type="checkbox"][data-share-format-for]') && target.checked) {
+                    const typeCheckbox = document.querySelector(
+                        `input[data-share-type="${target.getAttribute('data-share-format-for')}"]`
+                    );
+                    if (typeCheckbox) typeCheckbox.checked = true;
+                }
+            });
+
+            const newShareLinkToggle = document.querySelector('[data-toggle-new-share-link]');
+            if (newShareLinkToggle) {
+                newShareLinkToggle.addEventListener('click', () => {
+                    document.getElementById('newShareLinkForm').classList.toggle('hidden');
+                });
             }
 
             document.getElementById('collectionBackupInput').onchange = function (e) {

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -13,6 +13,13 @@
 
     <div class="max-w-screen-xl mx-auto px-1 md:px-0 pb-12">
 
+        <% if (locals.isShareView) { %>
+            <div class="mt-6 flex items-center gap-3 bg-primary-theme/10 border border-primary-theme/30 rounded-2xl px-4 py-3">
+                <i class="fa-solid fa-eye text-primary-theme"></i>
+                <p class="text-xs font-bold text-primary-theme"><%= t('collection.share_view_banner') %></p>
+            </div>
+        <% } %>
+
         <div class="pt-6 mb-6 flex items-center justify-between">
             <h1 class="text-3xl font-bold transition-colors flex flex-col md:flex-row md:items-center gap-2 md:gap-3">
                 <span>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -150,7 +150,7 @@
   <link rel="apple-touch-icon" href="<%= baseUrl %>/ressources/icone-192.png">
 </head>
 
-<body class="font-sans transition-colors duration-300">
+<body class="font-sans transition-colors duration-300 min-h-screen flex flex-col">
     
   <div id="page-loader" class="fixed inset-0 z-[9999] flex flex-col items-center justify-center transition-opacity duration-500">
     <div class="relative">
@@ -266,6 +266,11 @@
             </ul>
           </div>
         </div>
+        <% } else if (locals.isShareView) { %>
+          <span class="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-primary-theme">
+            <i class="fa-solid fa-eye"></i>
+            <%= t('nav.share_view') %>
+          </span>
         <% } else { %>
           <a href="<%= baseUrl %>/login" class="text-sm font-bold text-primary-theme hover:underline"><%= t('nav.login') %></a>
         <% } %>
@@ -287,17 +292,39 @@
             if (typeof registry !== 'undefined' && registry) {
                 registry.getAll().forEach(p => {
                     (p.navbarShortcuts || []).forEach(s => {
-                        shortcutConfig[s.id] = { label: t(s.label), url: s.url, module: p.collectionType };
+                        shortcutConfig[s.id] = { label: t(s.label), url: s.url, module: p.collectionType, pluginId: p.id };
                     });
                 });
+            }
+
+            // A scoped share link only ever browses its allowlisted types/formats -
+            // drop shortcuts that would otherwise land a guest on an empty/blocked
+            // page, and drop account-only shortcuts (home, wishlist) that just
+            // bounce them to /login.
+            const shareScopeList = locals.isShareView ? (locals.shareScope || []) : null;
+            const shareScopeMap = shareScopeList && shareScopeList.length > 0
+                ? new Map(shareScopeList.map(s => [s.pluginId, s.formats || []]))
+                : null;
+
+            function shortcutAllowed(id, item) {
+                if (locals.isShareView && (id === 'global_home' || id === 'global_wishlist')) return false;
+                if (!shareScopeMap) return true;
+                if (!item.pluginId) return true;
+                if (!shareScopeMap.has(item.pluginId)) return false;
+                const allowedFormats = shareScopeMap.get(item.pluginId);
+                if (allowedFormats.length === 0) return true;
+                const qIndex = item.url.indexOf('?');
+                const params = new URLSearchParams(qIndex >= 0 ? item.url.slice(qIndex + 1) : '');
+                const fmt = params.get('format');
+                return !fmt || allowedFormats.includes(fmt);
             }
 
             if (settings && settings.navbarShortcuts) {
               settings.navbarShortcuts.forEach(id => {
                 const item = shortcutConfig[id];
-                if (item) {
+                if (item && shortcutAllowed(id, item)) {
                   const isModuleActive = item.module ? settings.modules[item.module] : true;
-                  
+
                   if (isModuleActive) { %>
                     <li>
                       <a href="<%= baseUrl + item.url %>" class="block py-2 px-3 md:p-0 text-[var(--text-sub)] hover:text-primary-theme transition-colors">
@@ -411,4 +438,4 @@
     });
   </script>
 
-  <main class="p-6">
+  <main class="p-6 flex-1">

--- a/views/partials/share-scope-picker.ejs
+++ b/views/partials/share-scope-picker.ejs
@@ -1,0 +1,33 @@
+<%
+  // Expected locals: sharePlugins (enabled plugins for this collection), scopeByType
+  // (map pluginId -> already-selected formats[]), idPrefix (unique per form on the
+  // page, so the type<->format auto-check script in admin.ejs can pair them up).
+%>
+<div class="space-y-3">
+    <% sharePlugins.forEach((p) => { %>
+        <div class="rounded-2xl bg-black/5 dark:bg-white/5 p-3">
+            <label class="flex items-center gap-3 cursor-pointer">
+                <input type="checkbox" name="scopeTypes" value="<%= p.id %>"
+                    data-share-type="<%= idPrefix %>_<%= p.id %>"
+                    <%= scopeByType.hasOwnProperty(p.id) ? 'checked' : '' %>
+                    class="w-4 h-4 rounded accent-primary-theme">
+                <i class="fa-solid fa-<%= p.icon %> text-primary-theme text-sm"></i>
+                <span class="text-sm font-bold"><%= t(p.label) %></span>
+            </label>
+            <% if ((p.formats || []).length > 0) { %>
+                <div class="mt-2 ml-7 flex flex-wrap gap-3">
+                    <% p.formats.forEach((f) => { %>
+                        <label class="flex items-center gap-1.5 text-xs cursor-pointer opacity-80">
+                            <input type="checkbox" name="scopeFormats_<%= p.id %>" value="<%= f.value %>"
+                                data-share-format-for="<%= idPrefix %>_<%= p.id %>"
+                                <%= (scopeByType[p.id] || []).includes(f.value) ? 'checked' : '' %>
+                                class="w-3.5 h-3.5 rounded accent-primary-theme">
+                            <%= t(f.label) %>
+                        </label>
+                    <% }) %>
+                </div>
+            <% } %>
+        </div>
+    <% }) %>
+    <p class="text-[11px] opacity-50"><%= t('admin.sharing.scope_empty_hint') %></p>
+</div>

--- a/views/share-invalid.ejs
+++ b/views/share-invalid.ejs
@@ -1,0 +1,19 @@
+<%- include('partials/header') %>
+
+<div class="max-w-screen-md mx-auto px-4 pt-24 pb-32">
+    <div class="card-theme rounded-[2.5rem] p-10 md:p-16 shadow-sm text-center transition-colors">
+        <div class="w-20 h-20 rounded-full bg-primary-theme/10 text-primary-theme flex items-center justify-center mx-auto mb-8">
+            <i class="fa-solid fa-link-slash text-3xl"></i>
+        </div>
+
+        <h1 class="text-2xl md:text-3xl font-black mb-4">
+            <%= t('share_invalid.title') %>
+        </h1>
+
+        <p class="text-sm opacity-60 leading-relaxed max-w-md mx-auto">
+            <%= t('share_invalid.message') %>
+        </p>
+    </div>
+</div>
+
+<%- include('partials/footer') %>


### PR DESCRIPTION
- Multiple independent share links per collection, each with its own token, optional label, enabled state and scope (whole collection or specific types/formats, e.g. only Vinyl+CD within Music)
- Server-rendered QR code per link, no third-party QR service involved
- Read-only enforced at the route layer: only the collection listing and item detail pages accept a share-link cookie in place of a real login; every mutating/admin route is untouched
- Nav bar and format/type filters hide anything outside an active link's scope for a share visitor
- Sticky footer fix (unrelated CSS bug found while building this)
- docs/sharing.md + README updates

<!-- Thanks for contributing to DVinyl! 🙌 Fill in the sections below so I can review quickly. -->

## What does this PR do?

<!-- A short description of the change and why it is needed. -->

## Related issue

<!-- Link an issue if there is one, e.g. Closes #123. Skip for tiny fixes. -->

## Type of change

- [X] 🐛 Bug fix
- [X} ✨ New feature
- [ ] 🧩 New or updated plugin
- [ ] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🧹 Refactor or chore

## Checklist

- [X] `make typecheck` passes
- [X] I tested my changes locally
- [X] I updated the docs or translations if needed
- [X] My change is focused on a single thing

## Screenshots

<img width="1285" height="512" alt="image" src="https://github.com/user-attachments/assets/59fce44d-b521-48cd-b6b1-679dfcbd7983" />

## Anything else?

Issue #100 
