### PR TITLE
fix: force https in share link/QR URLs when PROD=true

### DIFF
--- a/routes/adminRoutes.ts
+++ b/routes/adminRoutes.ts
@@ -18,6 +18,14 @@ import { registry } from "../core/registry.js";
 import { PermanentRefreshError, syncStamp } from "../core/helpers";
 import { deleteItemsAndContents } from "../utils/itemHelpers";
 
+// PROD=true is the operator's own declaration that the instance is served over HTTPS
+// (see docs/getting-started.md). Trust that over req.protocol, which depends on the
+// reverse proxy correctly forwarding X-Forwarded-Proto - a single misconfigured proxy
+// hop otherwise silently downgrades every generated share link/QR code to http.
+function getPublicProtocol(req: any): string {
+  return process.env.PROD === "true" ? "https" : req.protocol;
+}
+
 const router = express.Router();
 
 const createPassword = (length = 12): string => {
@@ -159,7 +167,7 @@ router.get("/", requireAuth, requireCollectionRole("admin"), async (req: any, re
       newPassword: null,
       // Share links must show a full, absolute URL (scheme + host) - a bare
       // baseUrl-relative path is not something you can scan/paste elsewhere.
-      siteOrigin: `${req.protocol}://${req.get("host")}`,
+      siteOrigin: `${getPublicProtocol(req)}://${req.get("host")}`,
     });
   } catch (err) {
     console.error(err);
@@ -746,7 +754,7 @@ router.get("/share/:token/qr.png", requireAuth, requireCollectionRole("admin"), 
     );
     if (!coll) return res.status(404).send(req.t("errors.not_found"));
 
-    const url = `${req.protocol}://${req.get("host")}${BASE_URL}/share/${req.params.token}`;
+    const url = `${getPublicProtocol(req)}://${req.get("host")}${BASE_URL}/share/${req.params.token}`;
     const png = await QRCode.toBuffer(url, { type: "png", width: 320, margin: 1 });
     res.set("Content-Type", "image/png");
     res.send(png);


### PR DESCRIPTION
Fixes #112.

## Problem

Share link / QR code URLs were built with `req.protocol`, which only
reports `https` when the reverse proxy correctly forwards
`X-Forwarded-Proto` and Express's `trust proxy` is set. A misconfigured
proxy hop silently downgraded every generated share link and QR code
to `http`, even with `PROD=true`.

## Fix

`PROD=true` is already the operator's own declaration (per
`docs/getting-started.md`) that the instance is served over HTTPS.
`routes/adminRoutes.ts` now trusts that flag directly when building the
public share URL (`siteOrigin`) and the QR code payload, instead of
relying solely on the forwarded-protocol header.

## Testing

Reproduced locally with an in-memory MongoDB instance, `PROD=false` vs
`PROD=true`. Confirmed the share link / QR code shows `http://` with
`PROD=false` and `https://` with `PROD=true`, without needing a real
reverse proxy in front of it.

Also could not reproduce the two other symptoms mentioned in #112
(invalid QR image / 404 on delete for non-default collections) against
current `main` - they may already be covered by earlier fixes
(`fbe3e58`, `0fdc5c3`). Left a comment on the issue with details.
