### PR TITLE
feat(backup): add CSV export for collections

### DIFF
--- a/core/csvMapping.ts
+++ b/core/csvMapping.ts
@@ -321,6 +321,38 @@ export function coerceValue(raw: string, field: ImportTargetField, booleans?: { 
 }
 
 /**
+ * Reads one destination field off an item for a spreadsheet export - the inverse of
+ * coerceValue(). Options resolve to their (already-translated) label rather than the
+ * stored value, so an exported sheet reads like the interface; coerceValue's own
+ * matchOption() still accepts either on the way back in.
+ */
+export function fieldValue(item: Record<string, any>, field: ImportTargetField): string {
+  const raw = field.extraField ? item.extra?.[field.name] : item[field.name];
+  if (raw === undefined || raw === null || raw === '') return '';
+
+  switch (field.type) {
+    case 'tags':
+      return Array.isArray(raw) ? raw.join('; ') : String(raw);
+    case 'date': {
+      const date = raw instanceof Date ? raw : new Date(raw);
+      return isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+    }
+    case 'boolean':
+      return raw ? 'true' : 'false';
+    case 'number':
+    case 'rating':
+      return String(raw);
+    default: {
+      if (field.options && field.options.length > 0) {
+        const hit = field.options.find(o => o.value === raw);
+        if (hit) return hit.label;
+      }
+      return String(raw);
+    }
+  }
+}
+
+/**
  * Drops what a mapping submission cannot honour (unknown fields, columns absent from
  * the file, empty constants) and reports the required destinations left unfed, which
  * are the ones without which the import can only produce rejected rows.

--- a/core/helpers.ts
+++ b/core/helpers.ts
@@ -344,6 +344,24 @@ export function parseCsvRecords(text: string, delimiter: string = ','): Record<s
 }
 
 /**
+ * Serializes a matrix of cells into RFC-4180 CSV text (CRLF rows, quoting only where a
+ * cell actually needs it). The counterpart to parseCsv(), for the spreadsheet export.
+ *
+ * A cell opening with =, +, -, @, tab or CR is neutralized with a leading apostrophe:
+ * spreadsheet apps read such a cell as a formula, and an item title or comment is a
+ * value the user typed, not something they meant Excel to execute.
+ */
+export function stringifyCsv(rows: string[][]): string {
+  const FORMULA_PREFIX = /^[=+\-@\t\r]/;
+  const escapeCell = (cell: string): string => {
+    let value = cell ?? '';
+    if (FORMULA_PREFIX.test(value)) value = "'" + value;
+    return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  };
+  return rows.map(row => row.map(escapeCell).join(',')).join('\r\n');
+}
+
+/**
  * Thrown by a plugin's refreshItem when no amount of waiting can make the call succeed:
  * the item carries no external id, or the API key is not configured. The bulk refresh
  * skips its retries for these, since the next attempt would fail for the same reason.

--- a/locales/de.json
+++ b/locales/de.json
@@ -57,7 +57,12 @@
     "backup": {
       "confirm_import": "ACHTUNG: Dadurch werden alle Ihre aktuellen Daten (Alben, Benutzer, Protokolle) gelöscht und durch den Inhalt der Datei ersetzt. Sie werden abgemeldet. Weitermachen?",
       "export_btn": "Datenbank exportieren",
+      "export_csv_btn": "CSV exportieren",
       "import_btn": "Datenbank importieren",
+      "csv": {
+        "type_column": "Typ",
+        "wishlist_column": "Wunschliste"
+      },
       "import_error": "Fehler beim Import.",
       "import_success": "Datenbank erfolgreich importiert.",
       "json_error": "Ungültige JSON-Datei.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -346,7 +346,12 @@
     },
     "backup": {
       "export_btn": "Export Database",
+      "export_csv_btn": "Export CSV",
       "import_btn": "Import Database",
+      "csv": {
+        "type_column": "Type",
+        "wishlist_column": "Wishlist"
+      },
       "import_success": "Database imported successfully.",
       "import_error": "Error during import.",
       "json_error": "Invalid JSON file.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -57,7 +57,12 @@
     "backup": {
       "confirm_import": "ADVERTENCIA: Esto eliminará todos sus datos actuales (álbumes, usuarios, registros) y los reemplazará con el contenido del archivo. Se cerrará tu sesión. ¿Continuar?",
       "export_btn": "Exportar base de datos",
+      "export_csv_btn": "Exportar CSV",
       "import_btn": "Importar base de datos",
+      "csv": {
+        "type_column": "Tipo",
+        "wishlist_column": "Lista de deseos"
+      },
       "import_error": "Error durante la importación.",
       "import_success": "Base de datos importada exitosamente.",
       "json_error": "Archivo JSON no válido.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -331,7 +331,12 @@
     },
     "backup": {
       "export_btn": "Exporter la base de données",
+      "export_csv_btn": "Exporter en CSV",
       "import_btn": "Importer la base de données",
+      "csv": {
+        "type_column": "Type",
+        "wishlist_column": "Liste de souhaits"
+      },
       "import_success": "Base de données importée avec succès.",
       "import_error": "Erreur lors de l'importation.",
       "json_error": "Fichier JSON invalide.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -57,7 +57,12 @@
     "backup": {
       "confirm_import": "ATTENZIONE: questa operazione eliminerà tutti i tuoi dati correnti (album, utenti, registri) e li sostituirà con il contenuto del file. Verrai disconnesso. Continuare?",
       "export_btn": "Esporta banca dati",
+      "export_csv_btn": "Esporta CSV",
       "import_btn": "Importa banca dati",
+      "csv": {
+        "type_column": "Tipo",
+        "wishlist_column": "Lista dei desideri"
+      },
       "import_error": "Errore durante l'importazione.",
       "import_success": "Database importato correttamente.",
       "json_error": "File JSON non valido.",

--- a/routes/backupRoutes.ts
+++ b/routes/backupRoutes.ts
@@ -277,7 +277,9 @@ router.get('/collection/export', requireAuth, requireCollectionRole('admin'), as
  * restorable dump. One row per item; columns are the union of the importable fields
  * (base + plugin + user-defined) of every kind actually present, so a single-type
  * collection reads as a clean sheet and a mixed one simply carries more (sparse)
- * columns. Read-only: unlike the JSON export this never round-trips through /import.
+ * columns. Fields shared by several plugins share a column only when they are the same
+ * field, see the identity check below. Read-only: unlike the JSON export this never
+ * round-trips through /import.
  */
 router.get('/collection/export-csv', requireAuth, requireCollectionRole('admin'), async (req: any, res: any) => {
     try {
@@ -287,29 +289,71 @@ router.get('/collection/export-csv', requireAuth, requireCollectionRole('admin')
 
         const albums = await Item.find({ collection: activeCollectionId }).lean();
 
-        const kinds = Array.from(new Set(albums.map((a: any) => a.kind)));
-        const columns: ImportTargetField[] = [];
-        const seen = new Set<string>();
+        // Registry order rather than the order Mongo happened to return the items in,
+        // so the same collection always exports its columns in the same order.
+        const present = new Set(albums.map((a: any) => a.kind));
+        const kinds = registry.getAll().map(p => p.kind).filter(kind => present.has(kind));
+
+        // A column is one field of one plugin. Two plugins merge into a single column
+        // only when their field is the same thing under the same name: the base fields
+        // (Title, Year...) do, media_type does not, since it holds vinyl/cd for music
+        // and movie/tv for DVDs. Merging those would print one plugin's labels and the
+        // other's raw values in a column headed with a name that fits half the rows.
+        const identity = (f: ImportTargetField) => JSON.stringify([
+            f.name, f.type, f.label, f.extraField === true,
+            (f.options || []).map(o => [o.value, o.label])
+        ]);
+
+        interface ExportColumn {
+            field: ImportTargetField;
+            label: string;
+            /** Left empty for any other kind, even one owning a field of the same name. */
+            kinds: Set<string>;
+            /** Names the module in the header when two columns end up reading alike. */
+            owner: string;
+        }
+
+        const columns: ExportColumn[] = [];
+        const byIdentity = new Map<string, ExportColumn>();
 
         for (const kind of kinds) {
             const plugin = registry.getByKind(kind);
-            if (!plugin) continue; // A kind whose plugin was since removed/disabled: skip its columns, keep its rows under "Type".
+            if (!plugin) continue; // Cannot happen, kinds come from the registry: narrows the type.
+            const pluginLabel = req.t(plugin.label, { defaultValue: plugin.id });
             for (const field of importableFields(plugin, settings, req.t)) {
-                if (seen.has(field.name)) continue;
-                seen.add(field.name);
-                columns.push(field);
+                const key = identity(field);
+                const known = byIdentity.get(key);
+                if (known) {
+                    known.kinds.add(kind);
+                    continue;
+                }
+                const column: ExportColumn = { field, label: field.label, kinds: new Set([kind]), owner: pluginLabel };
+                byIdentity.set(key, column);
+                columns.push(column);
             }
         }
 
         const typeLabel = req.t('admin.backup.csv.type_column');
         const wishlistLabel = req.t('admin.backup.csv.wishlist_column');
-        const header = [typeLabel, ...columns.map(f => f.label), wishlistLabel];
+
+        // Four modules label a field "Format", each with its own options, and the DVD
+        // plugin calls its own field "Type" like the module column added here: without
+        // this the sheet repeats a header and nobody can tell the columns apart. The two
+        // columns this route adds itself are counted in, and win the bare name.
+        const labelUses = new Map<string, number>([[typeLabel, 1], [wishlistLabel, 1]]);
+        for (const column of columns) labelUses.set(column.label, (labelUses.get(column.label) || 0) + 1);
+        for (const column of columns) {
+            if ((labelUses.get(column.label) || 0) > 1) column.label = `${column.label} (${column.owner})`;
+        }
+
+        const header = [typeLabel, ...columns.map(c => c.label), wishlistLabel];
 
         const rows: string[][] = [header];
         for (const album of albums) {
-            const plugin = registry.getByKind((album as any).kind);
-            const typeName = plugin ? req.t(plugin.label, { defaultValue: plugin.id }) : String((album as any).kind || '');
-            const cells = columns.map(field => fieldValue(album, field));
+            const kind = String((album as any).kind || '');
+            const plugin = registry.getByKind(kind);
+            const typeName = plugin ? req.t(plugin.label, { defaultValue: plugin.id }) : kind;
+            const cells = columns.map(c => (c.kinds.has(kind) ? fieldValue(album, c.field) : ''));
             rows.push([typeName, ...cells, (album as any).in_wishlist ? 'true' : 'false']);
         }
 

--- a/routes/backupRoutes.ts
+++ b/routes/backupRoutes.ts
@@ -10,7 +10,8 @@ import InstanceSettings from '../models/InstanceSettings';
 import { invalidateInstanceSettingsCache } from '../utils/instanceSettings';
 import { requireAuth, requireAdmin, requireCollectionRole } from '../middleware/authMiddleware';
 import { registry } from '../core/registry';
-import { buildSortTitle } from '../core/helpers';
+import { buildSortTitle, stringifyCsv } from '../core/helpers';
+import { importableFields, fieldValue, ImportTargetField } from '../core/csvMapping';
 
 // Stamped into every dump so a restore log says which build produced the file.
 // Read from package.json rather than copied, which is how it came to say 3.1.0 on 3.1.1.
@@ -267,6 +268,61 @@ router.get('/collection/export', requireAuth, requireCollectionRole('admin'), as
         res.send(JSON.stringify(data, null, 2));
     } catch (err) {
         console.error("[ERR] Collection export:", err);
+        res.status(500).send("Export failed");
+    }
+});
+
+/**
+ * GET /collection/export-csv - the same collection, as a flat spreadsheet instead of a
+ * restorable dump. One row per item; columns are the union of the importable fields
+ * (base + plugin + user-defined) of every kind actually present, so a single-type
+ * collection reads as a clean sheet and a mixed one simply carries more (sparse)
+ * columns. Read-only: unlike the JSON export this never round-trips through /import.
+ */
+router.get('/collection/export-csv', requireAuth, requireCollectionRole('admin'), async (req: any, res: any) => {
+    try {
+        const activeCollectionId = res.locals.activeCollectionId;
+        const collection = res.locals.activeCollection;
+        const settings = res.locals.settings;
+
+        const albums = await Item.find({ collection: activeCollectionId }).lean();
+
+        const kinds = Array.from(new Set(albums.map((a: any) => a.kind)));
+        const columns: ImportTargetField[] = [];
+        const seen = new Set<string>();
+
+        for (const kind of kinds) {
+            const plugin = registry.getByKind(kind);
+            if (!plugin) continue; // A kind whose plugin was since removed/disabled: skip its columns, keep its rows under "Type".
+            for (const field of importableFields(plugin, settings, req.t)) {
+                if (seen.has(field.name)) continue;
+                seen.add(field.name);
+                columns.push(field);
+            }
+        }
+
+        const typeLabel = req.t('admin.backup.csv.type_column');
+        const wishlistLabel = req.t('admin.backup.csv.wishlist_column');
+        const header = [typeLabel, ...columns.map(f => f.label), wishlistLabel];
+
+        const rows: string[][] = [header];
+        for (const album of albums) {
+            const plugin = registry.getByKind((album as any).kind);
+            const typeName = plugin ? req.t(plugin.label, { defaultValue: plugin.id }) : String((album as any).kind || '');
+            const cells = columns.map(field => fieldValue(album, field));
+            rows.push([typeName, ...cells, (album as any).in_wishlist ? 'true' : 'false']);
+        }
+
+        // Leading BOM so Excel (which guesses ANSI otherwise) opens accented labels
+        // and titles as UTF-8 instead of mojibake.
+        const csv = '﻿' + stringifyCsv(rows);
+        const slug = collection?.slug || 'collection';
+        const fileName = `dvinyl_collection-${slug}_${new Date().toISOString().split('T')[0]}.csv`;
+        res.setHeader('Content-disposition', 'attachment; filename=' + fileName);
+        res.setHeader('Content-type', 'text/csv; charset=utf-8');
+        res.send(csv);
+    } catch (err) {
+        console.error("[ERR] Collection CSV export:", err);
         res.status(500).send("Export failed");
     }
 });

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -369,6 +369,11 @@
                                     <i class="fa-solid fa-file-export"></i>
                                     <%= t('admin.backup.export_btn') %>
                                 </a>
+                                <a href="<%= baseUrl %>/backup/collection/export-csv"
+                                    class="flex-1 sm:flex-none bg-black/5 dark:bg-white/5 hover:bg-primary-theme hover:text-white px-6 py-3 rounded-xl font-bold text-sm transition-all flex items-center justify-center gap-2">
+                                    <i class="fa-solid fa-file-csv"></i>
+                                    <%= t('admin.backup.export_csv_btn') %>
+                                </a>
                                 <label
                                     class="flex-1 sm:flex-none bg-black/5 dark:bg-white/5 hover:bg-yellow-500 hover:text-white px-6 py-3 rounded-xl font-bold text-sm transition-all flex items-center justify-center gap-2 cursor-pointer">
                                     <i class="fa-solid fa-file-import"></i>


### PR DESCRIPTION
## Summary
- Adds a CSV export option alongside the existing JSON backup, so a collection can be opened directly in a spreadsheet.
- New `GET /collection/export-csv` endpoint builds a field union across all plugin kinds in the collection (adding `Type`/`Wishlist` columns) and streams RFC-4180-escaped CSV with a UTF-8 BOM.
- `fieldValue()` serializes typed fields for export (dates → ISO, tags → semicolon-separated, booleans → strings, select options → their labels) — the inverse of the existing CSV import's `coerceValue()`.
- Formula-injection protection: cells starting with `=`, `+`, `-`, `@`, tab, or CR are apostrophe-prefixed before quoting, so untrusted item data (titles, comments) can't execute when opened in Excel/Sheets.
- Export button added to the collection Backup settings page, with i18n strings added to all 5 supported locales (en, de, es, fr, it).

## Test plan
- [x] TypeScript compiles clean
- [x] Offline pipeline test: field union + type conversion across plugin kinds verified against fixture data
- [x] Formula-injection regression test: dangerous cells neutralized, safe data preserved, RFC-4180 quoting intact
- [x] Manual end-to-end: ran the app locally against MongoDB, logged in, exported a real collection via the new button, confirmed the downloaded CSV opens correctly with accurate data