### PR TITLE
feat: price/value history tracking for collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /mongo_data
 /mongo_data_test
 docker-compose.override.yml
+dvinyl_collection-*.csv
 .vscode/
 .claude/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CLAUDE.md
 /graphify-out
 /docs/roadmap.md
 /docs/superpowers
+/.superpowers

--- a/locales/de.json
+++ b/locales/de.json
@@ -836,6 +836,8 @@
     "condition_hint": "Basierend auf dem Zustand „Sehr gut“.",
     "estimate_desc": "Wir befragen den Discogs-Markt für jede Platte.",
     "estimate_title": "Schätzung...",
+    "history_empty": "Führen Sie diese Schätzung mindestens zweimal aus, um einen Trend zu sehen.",
+    "history_title": "Wertverlauf",
     "max_label": "Maximum (Neuwertig)",
     "min_label": "Minimum (G)",
     "start_btn": "Analyse starten"

--- a/locales/en.json
+++ b/locales/en.json
@@ -229,6 +229,8 @@
     "min_label": "Minimum (G)",
     "max_label": "Maximum (Mint)",
     "start_btn": "Start Analysis",
+    "history_title": "Value History",
+    "history_empty": "Run this estimate at least twice to see a trend.",
     "add_hub_title": "What do you want to add?",
     "add_hub_subtitle": "Select the type of media to add to your collection"
   },

--- a/locales/es.json
+++ b/locales/es.json
@@ -836,6 +836,8 @@
     "condition_hint": "Basado en condición \"Muy buena\"",
     "estimate_desc": "Estamos consultando el mercado de Discogs para cada disco.",
     "estimate_title": "Estimando...",
+    "history_empty": "Ejecuta esta estimación al menos dos veces para ver una tendencia.",
+    "history_title": "Historial de valor",
     "max_label": "Máximo (perfecto)",
     "min_label": "Mínimo (G)",
     "start_btn": "Iniciar análisis"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -229,6 +229,8 @@
     "min_label": "Minimum (G)",
     "max_label": "Maximum (Mint)",
     "start_btn": "Lancer l'analyse",
+    "history_title": "Historique de valeur",
+    "history_empty": "Lancez cette estimation au moins deux fois pour voir une tendance.",
     "add_hub_title": "On ajoute quoi ?",
     "add_hub_subtitle": "Sélectionnez le type de média à intégrer à votre collection"
   },

--- a/locales/it.json
+++ b/locales/it.json
@@ -836,6 +836,8 @@
     "condition_hint": "Basato su condizioni \"molto buone\".",
     "estimate_desc": "Stiamo interrogando il mercato Discogs per ogni record.",
     "estimate_title": "Stima...",
+    "history_empty": "Esegui questa stima almeno due volte per vedere una tendenza.",
+    "history_title": "Cronologia del valore",
     "max_label": "Massimo (nuovo)",
     "min_label": "Minimo (G)",
     "start_btn": "Avvia analisi"

--- a/models/PriceHistory.ts
+++ b/models/PriceHistory.ts
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+
+const priceHistorySchema = new mongoose.Schema({
+  collection: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Collection',
+    required: true
+  },
+  capturedAt: { type: Date, default: Date.now },
+  value: { type: Number, required: true },
+  minValue: { type: Number, required: true },
+  maxValue: { type: Number, required: true },
+  currency: { type: String, required: true },
+  itemCount: { type: Number, required: true }
+});
+
+priceHistorySchema.index({ collection: 1, capturedAt: 1 });
+
+export = mongoose.model('PriceHistory', priceHistorySchema);

--- a/plugins/music/apiRoutes.ts
+++ b/plugins/music/apiRoutes.ts
@@ -357,7 +357,7 @@ export const musicApiRoutes: PluginApiRoute[] = [
   { method: 'get', path: '/api/album/:id/track/:trackId/lyrics', handler: getTrackLyrics },
   { method: 'get', path: '/api/estimate/history', handler: getEstimateHistory },
   { method: 'get', path: '/api/estimate/:discogsId', handler: getEstimate },
-  { method: 'post', path: '/api/estimate/snapshot', handler: saveEstimateSnapshot },
+  { method: 'post', path: '/api/estimate/snapshot', requireEditor: true, handler: saveEstimateSnapshot },
   { method: 'get', path: '/api/search-discogs-gallery', requireAdmin: true, handler: searchDiscogsGallery },
   { method: 'post', path: '/api/batch-update-barcodes', requireAdmin: true, handler: batchUpdateBarcodes }
 ];

--- a/plugins/music/apiRoutes.ts
+++ b/plugins/music/apiRoutes.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { PluginApiRoute } from '../../core/types';
 import Item from '../../models/Item';
+import PriceHistory from '../../models/PriceHistory';
 import { editStamp } from '../../core/helpers';
 
 const fetchJson = async (url: string, options?: RequestInit): Promise<any> => {
@@ -125,6 +126,50 @@ async function getEstimate(req: any, res: any) {
   } catch (err: any) {
     console.error("Estimation server error:", err.message);
     res.json({ success: false, error: "Server error" });
+  }
+}
+
+// SAVE A COLLECTION VALUE SNAPSHOT (called client-side after the Estimate modal finishes)
+async function saveEstimateSnapshot(req: any, res: any) {
+  try {
+    const { value, minValue, maxValue, currency, itemCount } = req.body || {};
+
+    if (
+      typeof value !== 'number' || typeof minValue !== 'number' ||
+      typeof maxValue !== 'number' || typeof currency !== 'string' ||
+      typeof itemCount !== 'number'
+    ) {
+      return res.status(400).json({ success: false, error: 'invalid_payload' });
+    }
+
+    await PriceHistory.create({
+      collection: res.locals.activeCollectionId,
+      value,
+      minValue,
+      maxValue,
+      currency,
+      itemCount
+    });
+
+    res.json({ success: true });
+  } catch (err: any) {
+    console.error('[ERR] saveEstimateSnapshot:', err.message);
+    res.status(500).json({ success: false, error: 'server_error' });
+  }
+}
+
+// COLLECTION VALUE HISTORY (chart data source)
+async function getEstimateHistory(req: any, res: any) {
+  try {
+    const snapshots = await PriceHistory.find({ collection: res.locals.activeCollectionId })
+      .sort({ capturedAt: 1 })
+      .select('capturedAt value minValue maxValue currency itemCount -_id')
+      .lean();
+
+    res.json({ success: true, snapshots });
+  } catch (err: any) {
+    console.error('[ERR] getEstimateHistory:', err.message);
+    res.status(500).json({ success: false, error: 'server_error' });
   }
 }
 
@@ -310,7 +355,9 @@ export const musicApiRoutes: PluginApiRoute[] = [
   { method: 'get', path: '/api/collection/ids', handler: getCollectionIds },
   { method: 'post', path: '/api/album/:id/track/:trackId/meta', requireEditor: true, handler: updateTrackMeta },
   { method: 'get', path: '/api/album/:id/track/:trackId/lyrics', handler: getTrackLyrics },
+  { method: 'get', path: '/api/estimate/history', handler: getEstimateHistory },
   { method: 'get', path: '/api/estimate/:discogsId', handler: getEstimate },
+  { method: 'post', path: '/api/estimate/snapshot', handler: saveEstimateSnapshot },
   { method: 'get', path: '/api/search-discogs-gallery', requireAdmin: true, handler: searchDiscogsGallery },
   { method: 'post', path: '/api/batch-update-barcodes', requireAdmin: true, handler: batchUpdateBarcodes }
 ];

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -1117,7 +1117,7 @@
             } catch (e) { }
         }
 
-        function showResults() {
+        async function showResults() {
             const fmt = (val) => {
                 try {
                     return new Intl.NumberFormat(currentLocale, {
@@ -1135,6 +1135,26 @@
 
             document.getElementById('progressContainer').classList.add('hidden');
             resultDiv.classList.remove('hidden');
+
+            try {
+                await fetch('<%= baseUrl %>/api/estimate/snapshot', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        value: totalPriceVG,
+                        minValue: totalPriceMin,
+                        maxValue: totalPriceMax,
+                        currency: currentCurrency,
+                        itemCount: totalAlbums
+                    })
+                });
+            } catch (e) { /* history is a bonus, don't block the result on it */ }
+
+            try {
+                const histRes = await fetch('<%= baseUrl %>/api/estimate/history');
+                const histData = await histRes.json();
+                if (histData.success) renderHistoryChart(histData.snapshots);
+            } catch (e) { /* chart is a bonus, don't block the result on it */ }
         }
     <% } %>
         function toggleDecadeMenu(e) {

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -1072,6 +1072,10 @@
         let totalPriceVG = 0;
         let totalPriceMin = 0;
         let totalPriceMax = 0;
+        // Albums that actually returned a usable price (as opposed to merely attempted):
+        // used to decide whether the resulting total is representative enough to persist
+        // as a history snapshot. See showResults().
+        let pricedCount = 0;
 
         function openEstimateModal(action) {
             if (action && action.estimate) activeEstimate = action.estimate;
@@ -1097,6 +1101,7 @@
                 totalPriceVG = 0;
                 totalPriceMin = 0;
                 totalPriceMax = 0;
+                pricedCount = 0;
 
                 countSpan.innerText = `0 / ${totalAlbums}`;
 
@@ -1112,7 +1117,7 @@
 
                     await new Promise(r => setTimeout(r, 500));
                 }
-                showResults();
+                await showResults();
             } catch (err) {
                 alert(`${estimateErrorMsg} : ${err.message}`);
                 startBtn.classList.remove('hidden');
@@ -1128,6 +1133,7 @@
                     totalPriceVG += val;
                     totalPriceMin += val;
                     totalPriceMax += (val * (activeEstimate.maxMultiplier || 1.3));
+                    pricedCount++;
                 }
             } catch (e) { }
         }
@@ -1151,25 +1157,52 @@
             document.getElementById('progressContainer').classList.add('hidden');
             resultDiv.classList.remove('hidden');
 
-            try {
-                await fetch('<%= baseUrl %>/api/estimate/snapshot', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        value: totalPriceVG,
-                        minValue: totalPriceMin,
-                        maxValue: totalPriceMax,
-                        currency: currentCurrency,
-                        itemCount: totalAlbums
-                    })
-                });
-            } catch (e) { /* history is a bonus, don't block the result on it */ }
+            // A run where most albums failed to price (Discogs rate-limiting, a missing/expired
+            // token, or a zero-item collection) produces a total that isn't representative of the
+            // collection's real value. Persisting that as a permanent history point would read as
+            // "the collection dropped in value" when really the estimate just mostly failed. Only
+            // write a snapshot when at least half the attempted albums actually returned a price.
+            // The on-screen result above still reflects whatever was priced, unconditionally.
+            const shouldPersistSnapshot = pricedCount > 0 && pricedCount >= totalAlbums / 2;
 
+            if (shouldPersistSnapshot) {
+                try {
+                    await fetch('<%= baseUrl %>/api/estimate/snapshot', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            value: totalPriceVG,
+                            minValue: totalPriceMin,
+                            maxValue: totalPriceMax,
+                            currency: currentCurrency,
+                            itemCount: totalAlbums
+                        })
+                    });
+                } catch (e) { /* history is a bonus, don't block the result on it */ }
+            }
+
+            const canvas = document.getElementById('historyChart');
+            const emptyMsg = document.getElementById('historyEmpty');
             try {
                 const histRes = await fetch('<%= baseUrl %>/api/estimate/history');
                 const histData = await histRes.json();
-                if (histData.success) renderHistoryChart(histData.snapshots);
-            } catch (e) { /* chart is a bonus, don't block the result on it */ }
+                if (histData.success) {
+                    // Snapshots are scoped per-collection but currency is a per-user setting:
+                    // members with different currency preferences could have written mixed-currency
+                    // points into the same series. Only show this user's own currency so values are
+                    // never silently mixed without conversion.
+                    const ownCurrencySnapshots = (histData.snapshots || []).filter(s => s.currency === currentCurrency);
+                    renderHistoryChart(ownCurrencySnapshots);
+                } else {
+                    canvas.classList.add('hidden');
+                    emptyMsg.classList.remove('hidden');
+                }
+            } catch (e) {
+                // The fetch itself failed (network error, etc.): show the same empty state as a
+                // genuinely empty history rather than leaving a blank canvas under the heading.
+                canvas.classList.add('hidden');
+                emptyMsg.classList.remove('hidden');
+            }
         }
 
         let historyChartInstance = null;
@@ -1191,6 +1224,28 @@
             const values = snapshots.map(s => s.value);
             const mins = snapshots.map(s => s.minValue);
             const maxs = snapshots.map(s => s.maxValue);
+            // Caller already filtered to a single currency, so any snapshot's currency stands
+            // in for the whole series; fall back to the viewer's own currency if it's somehow absent.
+            const seriesCurrency = (snapshots[0] && snapshots[0].currency) || currentCurrency;
+            const fmtCurrency = (val) => {
+                try {
+                    return new Intl.NumberFormat(currentLocale, { style: 'currency', currency: seriesCurrency }).format(val);
+                } catch (e) {
+                    return val.toFixed(2) + ' ' + seriesCurrency;
+                }
+            };
+
+            // Canvas 2D has no CSS cascade: Chart.js hands these strings straight to
+            // ctx.strokeStyle/ctx.fillStyle, which silently ignores unresolved var(...) calls.
+            // Resolve the custom property to its actual value here instead. --highlight-rgb is
+            // stored as space-separated channels (e.g. "16 185 129", Tailwind-v3-style for use
+            // inside rgb(... / <alpha-value>)), so it plugs directly into rgb()'s space/slash syntax.
+            const highlightRgb = getComputedStyle(document.documentElement)
+                .getPropertyValue('--highlight-rgb').trim() || '16 185 129';
+            const accentColor = `rgb(${highlightRgb})`;
+            const bandColor = `rgb(${highlightRgb} / 0.12)`;
+            const tickColor = getComputedStyle(document.documentElement)
+                .getPropertyValue('--text-sub').trim() || '#888888';
 
             if (historyChartInstance) historyChartInstance.destroy();
 
@@ -1204,7 +1259,7 @@
                             data: maxs,
                             borderWidth: 0,
                             pointRadius: 0,
-                            backgroundColor: 'rgba(var(--highlight-rgb), 0.12)',
+                            backgroundColor: bandColor,
                             fill: '+1'
                         },
                         {
@@ -1212,14 +1267,14 @@
                             data: mins,
                             borderWidth: 0,
                             pointRadius: 0,
-                            backgroundColor: 'rgba(var(--highlight-rgb), 0.12)',
+                            backgroundColor: bandColor,
                             fill: false
                         },
                         {
                             label: 'Value',
                             data: values,
-                            borderColor: 'rgb(var(--highlight-rgb))',
-                            backgroundColor: 'rgb(var(--highlight-rgb))',
+                            borderColor: accentColor,
+                            backgroundColor: accentColor,
                             borderWidth: 2,
                             pointRadius: 3,
                             fill: false
@@ -1228,9 +1283,27 @@
                 },
                 options: {
                     responsive: true,
-                    plugins: { legend: { display: false } },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: (ctx) => `${ctx.dataset.label}: ${fmtCurrency(ctx.parsed.y)}`
+                            }
+                        }
+                    },
                     scales: {
-                        y: { beginAtZero: false }
+                        x: {
+                            ticks: { color: tickColor },
+                            grid: { color: tickColor }
+                        },
+                        y: {
+                            beginAtZero: false,
+                            ticks: {
+                                color: tickColor,
+                                callback: (val) => fmtCurrency(val)
+                            },
+                            grid: { color: tickColor }
+                        }
                     }
                 }
             });

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -568,6 +568,12 @@
     </div>
 
     <% if (hasEstimateAction) { %>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"
+        integrity="sha384-vsrfeLOOY6KuIYKDlmVH5UiBmgIdB1oEf7p01YgWHuqmOHfZr374+odEv96n9tNC"
+        crossorigin="anonymous"></script>
+    <% } %>
+
+    <% if (hasEstimateAction) { %>
     <div id="estimateModal"
         class="fixed inset-0 z-50 hidden bg-black/80 backdrop-blur-sm flex items-center justify-center p-4">
         <div class="card-theme rounded-2xl w-full max-w-lg p-6 md:p-8 shadow-2xl relative">
@@ -616,6 +622,15 @@
                         </span>
                         <span id="maxPrice" class="font-bold text-lg">--</span>
                     </div>
+                </div>
+                <div class="mt-2">
+                    <p class="opacity-60 text-xs uppercase font-bold tracking-wider mb-2 text-left">
+                        <%= t('modal.history_title') %>
+                    </p>
+                    <canvas id="historyChart" height="120"></canvas>
+                    <p id="historyEmpty" class="hidden text-xs opacity-50 text-center py-4">
+                        <%= t('modal.history_empty') %>
+                    </p>
                 </div>
             </div>
 
@@ -1155,6 +1170,70 @@
                 const histData = await histRes.json();
                 if (histData.success) renderHistoryChart(histData.snapshots);
             } catch (e) { /* chart is a bonus, don't block the result on it */ }
+        }
+
+        let historyChartInstance = null;
+
+        function renderHistoryChart(snapshots) {
+            const canvas = document.getElementById('historyChart');
+            const emptyMsg = document.getElementById('historyEmpty');
+
+            if (!snapshots || snapshots.length < 2) {
+                canvas.classList.add('hidden');
+                emptyMsg.classList.remove('hidden');
+                return;
+            }
+
+            canvas.classList.remove('hidden');
+            emptyMsg.classList.add('hidden');
+
+            const labels = snapshots.map(s => new Date(s.capturedAt).toLocaleDateString(currentLocale));
+            const values = snapshots.map(s => s.value);
+            const mins = snapshots.map(s => s.minValue);
+            const maxs = snapshots.map(s => s.maxValue);
+
+            if (historyChartInstance) historyChartInstance.destroy();
+
+            historyChartInstance = new Chart(canvas, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: 'Max',
+                            data: maxs,
+                            borderWidth: 0,
+                            pointRadius: 0,
+                            backgroundColor: 'rgba(var(--highlight-rgb), 0.12)',
+                            fill: '+1'
+                        },
+                        {
+                            label: 'Min',
+                            data: mins,
+                            borderWidth: 0,
+                            pointRadius: 0,
+                            backgroundColor: 'rgba(var(--highlight-rgb), 0.12)',
+                            fill: false
+                        },
+                        {
+                            label: 'Value',
+                            data: values,
+                            borderColor: 'rgb(var(--highlight-rgb))',
+                            backgroundColor: 'rgb(var(--highlight-rgb))',
+                            borderWidth: 2,
+                            pointRadius: 3,
+                            fill: false
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        y: { beginAtZero: false }
+                    }
+                }
+            });
         }
     <% } %>
         function toggleDecadeMenu(e) {


### PR DESCRIPTION
## Summary
- Adds a `PriceHistory` model that stores collection value snapshots (min/max estimate, currency, timestamp)
- Adds snapshot save/read routes to the music plugin API, gated with `requireEditor`
- Captures a snapshot automatically when the Estimate modal finishes a run, and renders a value-over-time chart (Chart.js) alongside the estimate results
- Chart resolves theme colors via `getComputedStyle` since Canvas 2D has no CSS cascade for `var(...)`
- Empty-state UI when history fetch fails or returns no data; zero/partial estimate runs are not persisted as data points

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Local end-to-end: ran Estimate on a live collection, confirmed snapshot save + chart render
- [x] Role-gating verified live: editor/admin write access 200 OK, viewer role blocked 403
- [x] Whole-branch review (1 Critical + 4 Important + 2 Minor) addressed in a single fix wave, re-verified

<img width="575" height="648" alt="image" src="https://github.com/user-attachments/assets/74d26fb3-eae7-4163-809b-c69bf9a7360f" />
