### PR TITLE
fix: translate configured card field values

### DIFF
--- a/core/cardFields.ts
+++ b/core/cardFields.ts
@@ -25,8 +25,14 @@ export interface CardLine {
   name: string;
   label: string;
   value: string;
+  translateValue: boolean;
   showLabel: boolean;
   style: 'text' | 'pill' | 'dot';
+}
+
+interface StringifiedValue {
+  value: string;
+  translate: boolean;
 }
 
 /**
@@ -46,26 +52,30 @@ export function cardFieldCandidates(plugin: PluginDefinition): FieldDefinition[]
   );
 }
 
-function stringifyValue(field: FieldDefinition | undefined, raw: any, lang?: string): string {
-  if (raw === undefined || raw === null || raw === '') return '';
+function stringifyValue(field: FieldDefinition | undefined, raw: any, lang?: string): StringifiedValue {
+  if (raw === undefined || raw === null || raw === '') return { value: '', translate: false };
 
-  if (Array.isArray(raw)) return raw.filter(Boolean).map(String).join(', ');
+  if (Array.isArray(raw)) return { value: raw.filter(Boolean).map(String).join(', '), translate: false };
   // Date-only values are stored as UTC midnight, so they are formatted in UTC too:
   // the local reading of a server east of Greenwich would show the day before.
   // Same rule as the item page, which is where the user checks the date.
-  if (raw instanceof Date) return raw.toLocaleDateString(dateLocaleFor(lang), { timeZone: 'UTC' });
+  if (raw instanceof Date) {
+    return { value: raw.toLocaleDateString(dateLocaleFor(lang), { timeZone: 'UTC' }), translate: false };
+  }
 
   if (typeof raw === 'boolean') {
     // A true flag shows as its own label ("Signed"); a false one is simply not a line
-    return raw && field ? field.label : '';
+    return { value: raw && field ? field.label : '', translate: raw && !!field };
   }
 
-  if (field?.type === 'select') {
+  if (field?.type === 'select' || field?.type === 'radio-cards') {
     const option = (field.options || []).find(o => String(o.value) === String(raw));
-    return option ? option.label : String(raw);
+    return option
+      ? { value: option.label, translate: true }
+      : { value: String(raw), translate: false };
   }
 
-  return String(raw);
+  return { value: String(raw), translate: false };
 }
 
 /**
@@ -154,16 +164,17 @@ export function getCardLines(
     // A plugin may rewrite its own value for the card (e.g. music trimming the noise
     // words out of format_type); anything else falls back to the generic reading.
     const override = plugin.cardFieldValue?.(name, item);
-    const value = override !== undefined && override !== null
-      ? override
+    const resolved = override !== undefined && override !== null
+      ? { value: override, translate: false }
       : stringifyValue(field, item[name] ?? item.extra?.[name], options.lang);
 
-    if (!value) continue;
+    if (!resolved.value) continue;
 
     lines.push({
       name,
       label: field?.label || name,
-      value,
+      value: resolved.value,
+      translateValue: resolved.translate,
       // The creator reads naturally on its own, and the decorated styles are too
       // small to carry a label. A true boolean already renders as its own label,
       // so keeping it here would print the name twice.

--- a/views/partials/item-card-body.ejs
+++ b/views/partials/item-card-body.ejs
@@ -30,7 +30,8 @@
   const cardLines = getCardLines(plugin, item, { lang: currentLng, isShareView: locals.isShareView === true });
   const plainLines = cardLines.filter(l => l.style === 'text');
   const markedLines = cardLines.filter(l => l.style !== 'text');
-  const lineText = l => (l.showLabel ? t(l.label, { defaultValue: l.label }) + ' : ' : '') + l.value;
+  const valueText = l => l.translateValue ? t(l.value, { defaultValue: l.value }) : l.value;
+  const lineText = l => (l.showLabel ? t(l.label, { defaultValue: l.label }) + ' : ' : '') + valueText(l);
 %>
 <div class="<%= cs.wrap %>">
     <h3 class="<%= cs.title %>" title="<%= item.title %>"><%= item.title %></h3>
@@ -45,7 +46,7 @@
 
     <% plainLines.forEach((line, i) => { %>
         <p class="<%= i === 0 ? cs.lead : 'text-[10px] md:text-xs opacity-60 truncate' %>" title="<%= lineText(line) %>">
-            <% if (line.showLabel) { %><span class="opacity-70"><%= t(line.label, { defaultValue: line.label }) %> :</span> <% } %><%= line.value %>
+            <% if (line.showLabel) { %><span class="opacity-70"><%= t(line.label, { defaultValue: line.label }) %> :</span> <% } %><%= valueText(line) %>
         </p>
     <% }) %>
 
@@ -54,12 +55,12 @@
             <% markedLines.forEach(line => { %>
                 <% if (line.style === 'pill') { %>
                     <span class="text-[9px] md:text-[10px] opacity-60 bg-black/5 dark:bg-white/10 px-1.5 py-0.5 rounded border border-transparent truncate max-w-[50%] font-medium transition-colors" title="<%= lineText(line) %>">
-                        <%= line.value %>
+                        <%= valueText(line) %>
                     </span>
                 <% } else { %>
                     <div class="flex items-center gap-1 min-w-0 truncate" title="<%= lineText(line) %>">
                         <span class="w-1.5 h-1.5 rounded-full bg-primary-theme inline-block flex-shrink-0"></span>
-                        <span class="text-[9px] md:text-[10px] opacity-60 truncate"><%= line.value %></span>
+                        <span class="text-[9px] md:text-[10px] opacity-60 truncate"><%= valueText(line) %></span>
                     </div>
                 <% } %>
             <% }) %>


### PR DESCRIPTION
## What does this PR do?

Translates configured card field values when they come from select, radio-card, or boolean field labels.

This fixes raw i18n keys such as `confirm_dvd.status_watched` appearing on collection cards instead of their translated value.

Free-text values and plugin-provided overrides remain unchanged to avoid translating user content accidentally.

## Related issue

No related issue, this is a small, focused bug fix.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧩 New or updated plugin
- [ ] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🧹 Refactor or chore

## Checklist

- [x] `make typecheck` / `npx tsc --noEmit` passes
- [x] I tested my changes locally
- [x] I updated the docs or translations if needed
- [x] My change is focused on a single thing

## Screenshots

Tested on the DVD collection cards in French:

- `watched` now renders as `Vu`
- `to_watch` now renders as `À voir`
- raw `confirm_dvd.status_*` keys are no longer displayed

Before:
<img width="864" height="300" alt="image" src="https://github.com/user-attachments/assets/0df5a9ee-70b4-4ac7-8b20-13d9eada1fd8" />

After:
<img width="749" height="273" alt="image" src="https://github.com/user-attachments/assets/59e86357-ae10-448e-8ec4-07d0c90d156d" />

## Anything else?

The fix is generic and also covers configured status fields for books and games.