### PR TITLE
Printable QR/barcode labels: per-item, bulk sheet, and select-all

### DIFF
--- a/core/helpers.ts
+++ b/core/helpers.ts
@@ -362,6 +362,16 @@ export function stringifyCsv(rows: string[][]): string {
 }
 
 /**
+ * True protocol DVinyl is served over. Trusts the operator's own PROD flag over
+ * req.protocol, which depends on the reverse proxy correctly forwarding
+ * X-Forwarded-Proto - a single misconfigured proxy hop otherwise silently downgrades
+ * a generated absolute URL (share link, QR code, item label) to http.
+ */
+export function getPublicProtocol(req: any): string {
+  return process.env.PROD === 'true' ? 'https' : req.protocol;
+}
+
+/**
  * Thrown by a plugin's refreshItem when no amount of waiting can make the call succeed:
  * the item carries no external id, or the API key is not configured. The bulk refresh
  * skips its retries for these, since the next attempt would fail for the same reason.

--- a/core/helpers.ts
+++ b/core/helpers.ts
@@ -1,3 +1,4 @@
+import bwipjs from 'bwip-js';
 import { BASE_URL } from '../config/constants';
 
 /**
@@ -369,6 +370,40 @@ export function stringifyCsv(rows: string[][]): string {
  */
 export function getPublicProtocol(req: any): string {
   return process.env.PROD === 'true' ? 'https' : req.protocol;
+}
+
+/**
+ * Renders an item's stored barcode (whatever a scan or a manual entry left in it) as a
+ * scannable Code128 image, base64-encoded for direct embedding in a label view.
+ *
+ * Code128 over EAN-13/UPC-A: the barcode field holds whatever was scanned or typed,
+ * which is not always a clean 12/13-digit retail code (an ISBN-10, a manually corrected
+ * value, an import artifact). Code128 encodes any of that without a digit-count or
+ * checksum requirement that would otherwise reject it. Returns null rather than
+ * throwing so one unprintable value skips its barcode instead of failing the label.
+ */
+export async function generateBarcodeDataUrl(value: string): Promise<string | null> {
+  try {
+    const png = await bwipjs.toBuffer({
+      bcid: 'code128',
+      text: value,
+      scale: 3,
+      height: 10,
+      includetext: true,
+      textxalign: 'center',
+      // Without an explicit background, bwip-js leaves the PNG's background
+      // transparent (alpha 0) rather than opaque white. That renders fine on
+      // screen over a light page, but a scanner reading the raw pixels (zbar,
+      // and likely some dedicated barcode readers) fails to detect the symbol
+      // at all against transparency - confirmed by testing this exact output
+      // against zbarimg before and after adding this option.
+      backgroundcolor: 'FFFFFF',
+    });
+    return `data:image/png;base64,${png.toString('base64')}`;
+  } catch (err: any) {
+    console.warn(`[LABELS] Barcode generation failed for "${value}":`, err.message);
+    return null;
+  }
 }
 
 /**

--- a/core/routes/collectionRoute.ts
+++ b/core/routes/collectionRoute.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import mongoose from 'mongoose';
+import QRCode from 'qrcode';
 import { registry } from '../registry';
 import Item from '../../models/Item';
 import Collection from '../../models/Collection';
 import User from '../../models/User';
-import { requireAuth, requireAuthOrShareView } from '../../middleware/authMiddleware';
+import { BASE_URL } from '../../config/constants';
+import { requireAuth, requireAuthOrShareView, requireCollectionRole } from '../../middleware/authMiddleware';
 import { applyVisibilityFilter, applyEnabledModulesFilter, applyContainedFilter, applyShareScopeFilter } from '../../utils/visibilityHelper';
-import { escapeRegExp } from '../helpers';
+import { escapeRegExp, getPublicProtocol, generateBarcodeDataUrl } from '../helpers';
 import { generateUniqueSlug } from '../../utils/collectionHelpers';
 import { resolveShelfItems } from '../../utils/itemHelpers';
 import { checkCollectionCreation } from '../../utils/instanceSettings';
@@ -455,6 +457,74 @@ router.get('/collection', requireAuthOrShareView, async (req: any, res: any) => 
     });
   } catch (err: any) {
     console.error("Collection page loading error:", err.message);
+    res.status(500).send(req.t('errors.generic_server_error'));
+  }
+});
+
+// Bulk/sheet QR labels for a set of items picked on the collection page. Generic
+// rather than per-plugin: a mixed-type collection page can select items across
+// kinds in one go, so each item resolves its own plugin individually below.
+router.post('/collection/labels', requireAuth, requireCollectionRole('editor'), async (req: any, res: any) => {
+  try {
+    const activeCollectionId = res.locals.activeCollectionId;
+    if (!activeCollectionId) {
+      return res.redirect('/collection');
+    }
+
+    const rawIds = req.body?.ids;
+    const idList: string[] = Array.isArray(rawIds) ? rawIds : (rawIds ? [rawIds] : []);
+    const ids = idList
+      .filter((id: string) => mongoose.Types.ObjectId.isValid(id))
+      .slice(0, 200);
+
+    if (ids.length === 0) {
+      return res.redirect('/collection');
+    }
+
+    const query: any = { _id: { $in: ids }, collection: activeCollectionId };
+    applyVisibilityFilter(query, res.locals.isCollectionAdmin, res.locals.settings);
+
+    const items = await Item.find(query).lean();
+
+    // One code type for the whole sheet, picked once by the caller: a mixed sheet
+    // (some boxes QR, some barcode) would be confusing to scan through, so a barcode
+    // sheet skips items with no barcode value rather than falling back to QR per item.
+    const codeType: 'qr' | 'barcode' = req.body?.type === 'barcode' ? 'barcode' : 'qr';
+
+    const labels = (await Promise.all(items.map(async (item: any) => {
+      const plugin = registry.getByKind(item.kind);
+      if (!plugin) {
+        // A kind whose module got disabled since the item was added: skip it
+        // rather than fail the whole sheet over one stale item.
+        console.warn(`[LABELS] Skipping item ${item._id}: no plugin for kind "${item.kind}"`);
+        return null;
+      }
+
+      if (codeType === 'barcode') {
+        if (!item.barcode) {
+          console.warn(`[LABELS] Skipping item ${item._id}: no barcode value for a barcode sheet`);
+          return null;
+        }
+        const barcodeDataUrl = await generateBarcodeDataUrl(item.barcode);
+        if (!barcodeDataUrl) {
+          console.warn(`[LABELS] Skipping item ${item._id}: barcode generation failed`);
+          return null;
+        }
+        return { item: plugin.formatForView(item), plugin, codeDataUrl: barcodeDataUrl };
+      }
+
+      const url = `${getPublicProtocol(req)}://${req.get('host')}${BASE_URL}${plugin.routePrefix}/${item._id}`;
+      const qrDataUrl = await QRCode.toDataURL(url, { width: 320, margin: 1 });
+      return { item: plugin.formatForView(item), plugin, codeDataUrl: qrDataUrl };
+    }))).filter(Boolean);
+
+    if (labels.length === 0) {
+      return res.redirect('/collection');
+    }
+
+    res.render('label-sheet', { labels, codeType, user: res.locals.user });
+  } catch (err: any) {
+    console.error('Bulk label error:', err.message);
     res.status(500).send(req.t('errors.generic_server_error'));
   }
 });

--- a/core/routes/itemRoutes.ts
+++ b/core/routes/itemRoutes.ts
@@ -6,7 +6,7 @@ import Item from '../../models/Item';
 import User from '../../models/User';
 import { BASE_URL } from '../../config/constants';
 import { requireAuth, requireAuthOrShareView, requireCollectionRole } from '../../middleware/authMiddleware';
-import { parseGenresAndStyles, isBarcodeQuery, lookupBarcodeTitle, searchWithTitleFallback, editStamp, syncStamp, safeReturnPath, getPublicProtocol } from '../helpers';
+import { parseGenresAndStyles, isBarcodeQuery, lookupBarcodeTitle, searchWithTitleFallback, editStamp, syncStamp, safeReturnPath, getPublicProtocol, generateBarcodeDataUrl } from '../helpers';
 import { DEFAULT_PLACEHOLDER_IMAGE } from '../placeholderImage';
 import { getExtraFields, toFieldDefinitions } from '../pluginExtraFields';
 import { buildFieldSuggestions } from '../fieldSuggestions';
@@ -641,7 +641,10 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
     }
   });
 
-  // GET /{prefix}/:id/label -> printable QR label linking back to the item's detail page
+  // GET /{prefix}/:id/label -> printable label, either a QR code linking back to the
+  // item's detail page or a barcode of its stored barcode value. ?type=barcode picks
+  // the barcode; anything else (including a missing/unavailable barcode) falls back
+  // to QR, so the two never render on the same label at once.
   router.get(`${plugin.routePrefix}/:id/label`, requireAuth, requireCollectionRole('editor'), async (req: any, res: any) => {
     try {
       if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
@@ -656,13 +659,26 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
         return res.status(404).send(req.t('errors.not_found'));
       }
 
-      const url = `${getPublicProtocol(req)}://${req.get('host')}${BASE_URL}${plugin.routePrefix}/${item._id}`;
-      const qrDataUrl = await QRCode.toDataURL(url, { width: 320, margin: 1 });
+      let codeType: 'qr' | 'barcode' = 'qr';
+      let codeDataUrl: string | null = null;
+
+      if (req.query.type === 'barcode' && item.barcode) {
+        codeDataUrl = await generateBarcodeDataUrl(item.barcode);
+        if (codeDataUrl) codeType = 'barcode';
+      }
+
+      if (!codeDataUrl) {
+        const url = `${getPublicProtocol(req)}://${req.get('host')}${BASE_URL}${plugin.routePrefix}/${item._id}`;
+        codeDataUrl = await QRCode.toDataURL(url, { width: 320, margin: 1 });
+        codeType = 'qr';
+      }
 
       res.render('label', {
         item: plugin.formatForView(item),
         plugin,
-        qrDataUrl,
+        codeType,
+        codeDataUrl,
+        hasBarcode: !!item.barcode,
         user: res.locals.user
       });
     } catch (err: any) {

--- a/core/routes/itemRoutes.ts
+++ b/core/routes/itemRoutes.ts
@@ -1,10 +1,12 @@
 import express, { Router } from 'express';
 import mongoose from 'mongoose';
+import QRCode from 'qrcode';
 import { PluginDefinition } from '../types';
 import Item from '../../models/Item';
 import User from '../../models/User';
+import { BASE_URL } from '../../config/constants';
 import { requireAuth, requireAuthOrShareView, requireCollectionRole } from '../../middleware/authMiddleware';
-import { parseGenresAndStyles, isBarcodeQuery, lookupBarcodeTitle, searchWithTitleFallback, editStamp, syncStamp, safeReturnPath } from '../helpers';
+import { parseGenresAndStyles, isBarcodeQuery, lookupBarcodeTitle, searchWithTitleFallback, editStamp, syncStamp, safeReturnPath, getPublicProtocol } from '../helpers';
 import { DEFAULT_PLACEHOLDER_IMAGE } from '../placeholderImage';
 import { getExtraFields, toFieldDefinitions } from '../pluginExtraFields';
 import { buildFieldSuggestions } from '../fieldSuggestions';
@@ -635,6 +637,36 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
       });
     } catch (err: any) {
       console.error(`Detail page error for ${plugin.id}:`, err.message);
+      res.status(500).send(req.t('errors.generic_server_error'));
+    }
+  });
+
+  // GET /{prefix}/:id/label -> printable QR label linking back to the item's detail page
+  router.get(`${plugin.routePrefix}/:id/label`, requireAuth, requireCollectionRole('editor'), async (req: any, res: any) => {
+    try {
+      if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+        return res.status(404).send(req.t('errors.not_found'));
+      }
+
+      const labelQuery: any = { _id: req.params.id, collection: res.locals.activeCollectionId };
+      applyVisibilityFilter(labelQuery, res.locals.isCollectionAdmin, res.locals.settings);
+
+      const item = await Item.findOne(labelQuery);
+      if (!item) {
+        return res.status(404).send(req.t('errors.not_found'));
+      }
+
+      const url = `${getPublicProtocol(req)}://${req.get('host')}${BASE_URL}${plugin.routePrefix}/${item._id}`;
+      const qrDataUrl = await QRCode.toDataURL(url, { width: 320, margin: 1 });
+
+      res.render('label', {
+        item: plugin.formatForView(item),
+        plugin,
+        qrDataUrl,
+        user: res.locals.user
+      });
+    } catch (err: any) {
+      console.error(`Label error for ${plugin.id}:`, err.message);
       res.status(500).send(req.t('errors.generic_server_error'));
     }
   });

--- a/core/views/detail.ejs
+++ b/core/views/detail.ejs
@@ -419,6 +419,10 @@
                             <%= t('detail.move_to_wishlist_btn') %>
                         </button>
                     <% } %>
+                    <a href="<%= baseUrl %><%= plugin.routePrefix %>/<%= item._id %>/label" target="_blank" rel="noopener" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">
+                        <i class="fa-solid fa-qrcode mr-2"></i>
+                        <%= t('detail.print_label_btn') %>
+                    </a>
                     <%# The origin travels on the link, since the Referer of the edit page
                         is this page and not the listing anyone wants to come back to. %>
                     <a href="<%= baseUrl %><%= plugin.routePrefix %>/edit/<%= item._id %><%= locals.backUrl ? '?from=' + encodeURIComponent(backUrl) : '' %>" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">

--- a/core/views/detail.ejs
+++ b/core/views/detail.ejs
@@ -419,10 +419,39 @@
                             <%= t('detail.move_to_wishlist_btn') %>
                         </button>
                     <% } %>
-                    <a href="<%= baseUrl %><%= plugin.routePrefix %>/<%= item._id %>/label" target="_blank" rel="noopener" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">
-                        <i class="fa-solid fa-qrcode mr-2"></i>
-                        <%= t('detail.print_label_btn') %>
-                    </a>
+                    <% if (item.barcode) { %>
+                        <%# One button, two destinations: hovering reveals a QR/barcode choice
+                            instead of two separate buttons crowding this row. Only offered when
+                            the item actually has a barcode - otherwise a "Barcode" option would
+                            just be a dead end that server-side falls back to QR anyway. %>
+                        <div class="relative group" id="labelDropdown">
+                            <button type="button" onclick="toggleLabelDropdown(event)" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 flex items-center gap-2">
+                                <i class="fa-solid fa-qrcode"></i>
+                                <%= t('detail.print_label_btn') %>
+                                <i class="fa-solid fa-chevron-down text-[10px] opacity-50"></i>
+                            </button>
+                            <%# Hover works on desktop via group-hover; the click handler above is
+                                a fallback for touchpads/touchscreens where :hover doesn't reliably
+                                fire, forcing the menu open with !block until an outside click. %>
+                            <div id="labelDropdownMenu" class="hidden group-hover:block absolute left-0 top-full pt-1 z-30 w-max min-w-full">
+                                <div class="card-theme border rounded-lg shadow-xl overflow-hidden">
+                                    <a href="<%= baseUrl %><%= plugin.routePrefix %>/<%= item._id %>/label" target="_blank" rel="noopener"
+                                        class="flex items-center gap-2 px-4 py-2.5 text-sm whitespace-nowrap hover:bg-black/5 dark:hover:bg-white/5 transition-colors">
+                                        <i class="fa-solid fa-qrcode w-4"></i> <%= t('detail.qr_option') %>
+                                    </a>
+                                    <a href="<%= baseUrl %><%= plugin.routePrefix %>/<%= item._id %>/label?type=barcode" target="_blank" rel="noopener"
+                                        class="flex items-center gap-2 px-4 py-2.5 text-sm whitespace-nowrap hover:bg-black/5 dark:hover:bg-white/5 transition-colors border-t border-black/5 dark:border-white/5">
+                                        <i class="fa-solid fa-barcode w-4"></i> <%= t('detail.barcode_option') %>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    <% } else { %>
+                        <a href="<%= baseUrl %><%= plugin.routePrefix %>/<%= item._id %>/label" target="_blank" rel="noopener" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">
+                            <i class="fa-solid fa-qrcode mr-2"></i>
+                            <%= t('detail.print_label_btn') %>
+                        </a>
+                    <% } %>
                     <%# The origin travels on the link, since the Referer of the edit page
                         is this page and not the listing anyone wants to come back to. %>
                     <a href="<%= baseUrl %><%= plugin.routePrefix %>/edit/<%= item._id %><%= locals.backUrl ? '?from=' + encodeURIComponent(backUrl) : '' %>" class="opacity-70 hover:opacity-100 hover:text-primary-theme px-4 py-2 text-sm transition-colors border border-black/10 dark:border-white/10 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">
@@ -471,6 +500,23 @@
         analyzing: t('detail.market_analysis'),
         error_server: t('messages.generic_error')
     }) %>;
+
+    // Click-to-toggle fallback for the QR/barcode label dropdown, alongside the
+    // CSS-only group-hover: touchpads/touchscreens don't reliably fire :hover.
+    function toggleLabelDropdown(e) {
+        e.stopPropagation();
+        const menu = document.getElementById('labelDropdownMenu');
+        if (!menu) return;
+        menu.classList.toggle('!block');
+        menu.classList.toggle('hidden');
+    }
+    document.addEventListener('click', (e) => {
+        const wrapper = document.getElementById('labelDropdown');
+        const menu = document.getElementById('labelDropdownMenu');
+        if (!wrapper || !menu || wrapper.contains(e.target)) return;
+        menu.classList.add('hidden');
+        menu.classList.remove('!block');
+    });
 
     const currentLocale = '<%= currentLng === "fr" ? "fr-FR" : "en-US" %>';
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -724,7 +724,9 @@
     "no_tracklist": "No tracklist available.",
     "refresh_info_success": "Metadata refreshed successfully!",
     "refresh_info_error": "Error refreshing metadata.",
-    "variants_title": "You also own this item in other versions:"
+    "variants_title": "You also own this item in other versions:",
+    "print_label_btn": "Print label",
+    "label_page_title": "Label"
   },
   "wishlist": {
     "title": "My Wishlist",

--- a/locales/en.json
+++ b/locales/en.json
@@ -637,7 +637,15 @@
     "search_style_placeholder": "Search styles...",
     "search_platform_placeholder": "Search consoles...",
     "active_filters": "Active filters:",
-    "page_jump_title": "Jump to page"
+    "page_jump_title": "Jump to page",
+    "select_btn": "Select",
+    "select_all": "Select all",
+    "deselect_all": "Deselect all",
+    "cancel_select": "Cancel",
+    "selected_count_suffix": "selected",
+    "print_selected_qr": "Print QR labels",
+    "print_selected_barcode": "Print barcode labels",
+    "label_sheet_title": "Print labels"
   },
   "confirm_vinyl": {
     "cover_preview": "Cover Preview",
@@ -726,6 +734,10 @@
     "refresh_info_error": "Error refreshing metadata.",
     "variants_title": "You also own this item in other versions:",
     "print_label_btn": "Print label",
+    "qr_option": "QR code",
+    "barcode_option": "Barcode",
+    "switch_to_qr": "Switch to QR code",
+    "switch_to_barcode": "Switch to barcode",
     "label_page_title": "Label"
   },
   "wishlist": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -637,7 +637,15 @@
     "search_style_placeholder": "Rechercher des styles...",
     "search_platform_placeholder": "Rechercher des consoles...",
     "active_filters": "Filtres actifs :",
-    "page_jump_title": "Aller à la page"
+    "page_jump_title": "Aller à la page",
+    "select_btn": "Sélectionner",
+    "select_all": "Tout sélectionner",
+    "deselect_all": "Tout désélectionner",
+    "cancel_select": "Annuler",
+    "selected_count_suffix": "sélectionné(s)",
+    "print_selected_qr": "Imprimer les QR codes",
+    "print_selected_barcode": "Imprimer les codes-barres",
+    "label_sheet_title": "Imprimer les étiquettes"
   },
   "confirm_vinyl": {
     "cover_preview": "Aperçu Pochette",
@@ -726,6 +734,10 @@
     "refresh_info_error": "Erreur lors de l'actualisation des métadonnées.",
     "variants_title": "Vous possédez également cet item dans d'autres versions :",
     "print_label_btn": "Imprimer l'étiquette",
+    "qr_option": "QR code",
+    "barcode_option": "Code-barres",
+    "switch_to_qr": "Passer au QR code",
+    "switch_to_barcode": "Passer au code-barres",
     "label_page_title": "Étiquette"
   },
   "wishlist": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -724,7 +724,9 @@
     "no_tracklist": "Aucune tracklist enregistrée.",
     "refresh_info_success": "Métadonnées actualisées avec succès !",
     "refresh_info_error": "Erreur lors de l'actualisation des métadonnées.",
-    "variants_title": "Vous possédez également cet item dans d'autres versions :"
+    "variants_title": "Vous possédez également cet item dans d'autres versions :",
+    "print_label_btn": "Imprimer l'étiquette",
+    "label_page_title": "Étiquette"
   },
   "wishlist": {
     "title": "Liste de Souhaits",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "bwip-js": "^4.11.4",
         "cookie-parser": "^1.4.7",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
@@ -1079,6 +1080,15 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bwip-js": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/bwip-js/-/bwip-js-4.11.4.tgz",
+      "integrity": "sha512-FOXnOQkinxog8FwxdnPB+8k2wRqwPnqXwxX37KcXOtMNW+9CinOkGv9MtIoRC4HX/UyogT0/9lIp6FDm2DcquQ==",
+      "license": "MIT",
+      "bin": {
+        "bwip-js": "bin/bwip-js.js"
       }
     },
     "node_modules/bytes": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "bwip-js": "^4.11.4",
     "cookie-parser": "^1.4.7",
     "ejs": "^3.1.10",
     "express": "^5.1.0",

--- a/routes/adminRoutes.ts
+++ b/routes/adminRoutes.ts
@@ -16,16 +16,8 @@ import Item from "../models/Item";
 
 import { registry } from "../core/registry.js";
 import { CARD_ASPECT_RATIOS } from "../core/customPlugin";
-import { PermanentRefreshError, syncStamp } from "../core/helpers";
+import { PermanentRefreshError, syncStamp, getPublicProtocol } from "../core/helpers";
 import { deleteItemsAndContents } from "../utils/itemHelpers";
-
-// PROD=true is the operator's own declaration that the instance is served over HTTPS
-// (see docs/getting-started.md). Trust that over req.protocol, which depends on the
-// reverse proxy correctly forwarding X-Forwarded-Proto - a single misconfigured proxy
-// hop otherwise silently downgrades every generated share link/QR code to http.
-function getPublicProtocol(req: any): string {
-  return process.env.PROD === "true" ? "https" : req.protocol;
-}
 
 const router = express.Router();
 

--- a/views/collection.ejs
+++ b/views/collection.ejs
@@ -42,6 +42,15 @@
                 %>
                     <div class="flex gap-2">
 
+                        <button type="button" id="selectModeBtn" onclick="toggleSelectMode()"
+                            class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group"
+                            title="<%= t('collection.select_btn') %>">
+                            <i class="fa-solid fa-check-double group-hover:scale-110 transition-transform"></i>
+                            <span class="hidden md:inline text-xs font-bold uppercase tracking-widest">
+                                <%= t('collection.select_btn') %>
+                            </span>
+                        </button>
+
                         <% if (addRoute) { %>
                             <a href="<%= baseUrl + addRoute %>"
                                 class="flex-shrink-0 w-10 h-10 md:w-auto md:px-4 card-theme hover:text-primary-theme hover:border-primary-theme rounded-lg transition-all shadow-sm flex items-center justify-center gap-2 group"
@@ -507,7 +516,7 @@
                 </div>
             <% } %>
         </div>
-        <%- include('partials/albums-grid', { albums, size: 'collection', gridId: 'albumGrid' }) %>
+        <%- include('partials/albums-grid', { albums, size: 'collection', gridId: 'albumGrid', selectable: locals.canEditCollection }) %>
         <div
             class="mt-12 flex flex-col md:flex-row items-center justify-between gap-6 border-t border-black/5 dark:border-white/10 pt-8">
 
@@ -566,6 +575,31 @@
                 <% } %>
         </div>
     </div>
+
+    <% if (locals.canEditCollection) { %>
+    <div id="bulkActionBar" class="hidden fixed bottom-6 inset-x-0 z-40 flex justify-center px-4">
+        <div class="card-theme border rounded-2xl shadow-2xl px-5 py-3 flex items-center gap-4">
+            <span id="bulkSelectedCount" class="text-sm font-bold opacity-80">0 <%= t('collection.selected_count_suffix') %></span>
+            <button type="button" id="selectAllBtn" onclick="toggleSelectAll()"
+                class="px-4 py-2 bg-black/5 dark:bg-white/10 rounded-lg text-sm font-bold hover:brightness-110 active:scale-95 transition-all">
+                <%= t('collection.select_all') %>
+            </button>
+            <button type="button" onclick="printSelectedLabels('qr')"
+                class="px-4 py-2 bg-primary-theme text-white rounded-lg text-sm font-bold hover:brightness-110 active:scale-95 transition-all">
+                <i class="fa-solid fa-qrcode mr-2"></i><%= t('collection.print_selected_qr') %>
+            </button>
+            <button type="button" onclick="printSelectedLabels('barcode')"
+                class="px-4 py-2 bg-primary-theme text-white rounded-lg text-sm font-bold hover:brightness-110 active:scale-95 transition-all">
+                <i class="fa-solid fa-barcode mr-2"></i><%= t('collection.print_selected_barcode') %>
+            </button>
+            <button type="button" onclick="cancelSelectMode()"
+                class="px-4 py-2 bg-black/5 dark:bg-white/10 rounded-lg text-sm font-bold hover:brightness-110 active:scale-95 transition-all">
+                <%= t('collection.cancel_select') %>
+            </button>
+        </div>
+    </div>
+    <form id="labelPrintForm" method="POST" action="<%= baseUrl %>/collection/labels" target="_blank" class="hidden"></form>
+    <% } %>
 
     <% if (hasEstimateAction) { %>
     <div id="estimateModal"
@@ -1002,6 +1036,90 @@
     
 
     <% if (locals.canEditCollection) { %>
+        // Bulk label printing: select mode toggles a checkbox overlay on every card
+        // (rendered but hidden by default, see partials/albums-grid) and turns card
+        // clicks into a selection toggle instead of a navigation.
+        let selectMode = false;
+        const selectedCountSuffix = <%- JSON.stringify(t('collection.selected_count_suffix')) %>;
+
+        function toggleSelectMode() {
+            selectMode = !selectMode;
+            document.querySelectorAll('.select-checkbox-overlay').forEach(el => {
+                el.classList.toggle('hidden', !selectMode);
+                el.classList.toggle('flex', selectMode);
+            });
+            document.querySelectorAll('.album-select-checkbox').forEach(cb => { cb.checked = false; });
+            const bar = document.getElementById('bulkActionBar');
+            if (bar) bar.classList.toggle('hidden', !selectMode);
+            const btn = document.getElementById('selectModeBtn');
+            if (btn) btn.classList.toggle('bg-primary-theme', selectMode);
+            if (btn) btn.classList.toggle('text-white', selectMode);
+            updateSelectedCount();
+        }
+
+        function cancelSelectMode() {
+            if (selectMode) toggleSelectMode();
+        }
+
+        function updateSelectedCount() {
+            const checkboxes = document.querySelectorAll('.album-select-checkbox');
+            const count = document.querySelectorAll('.album-select-checkbox:checked').length;
+            const countEl = document.getElementById('bulkSelectedCount');
+            if (countEl) countEl.textContent = count + ' ' + selectedCountSuffix;
+
+            const selectAllBtn = document.getElementById('selectAllBtn');
+            if (selectAllBtn) {
+                const allSelected = checkboxes.length > 0 && count === checkboxes.length;
+                selectAllBtn.textContent = allSelected
+                    ? <%- JSON.stringify(t('collection.deselect_all')) %>
+                    : <%- JSON.stringify(t('collection.select_all')) %>;
+            }
+        }
+
+        // Selects every card on the current page, or clears the selection if every
+        // card is already selected. Matches the v2a scope: current page only, not
+        // "select all matching filter" across pagination.
+        function toggleSelectAll() {
+            const checkboxes = [...document.querySelectorAll('.album-select-checkbox')];
+            const allSelected = checkboxes.length > 0 && checkboxes.every(cb => cb.checked);
+            checkboxes.forEach(cb => { cb.checked = !allSelected; });
+            updateSelectedCount();
+        }
+
+        function printSelectedLabels(type) {
+            const ids = [...document.querySelectorAll('.album-select-checkbox:checked')]
+                .map(cb => cb.closest('[data-id]')?.dataset.id)
+                .filter(Boolean);
+            if (ids.length === 0) return;
+            const form = document.getElementById('labelPrintForm');
+            form.innerHTML = '';
+            const typeInput = document.createElement('input');
+            typeInput.type = 'hidden';
+            typeInput.name = 'type';
+            typeInput.value = type;
+            form.appendChild(typeInput);
+            ids.forEach(id => {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = 'ids[]';
+                input.value = id;
+                form.appendChild(input);
+            });
+            form.submit();
+        }
+
+        document.getElementById('albumGrid')?.addEventListener('click', (e) => {
+            if (!selectMode) return;
+            const card = e.target.closest('.album-card');
+            if (!card) return;
+            e.preventDefault();
+            const checkbox = card.querySelector('.album-select-checkbox');
+            if (checkbox) {
+                checkbox.checked = !checkbox.checked;
+                updateSelectedCount();
+            }
+        });
+
         // Collection-level actions declared by the active plugin (see CollectionAction).
         const COLLECTION_ACTIONS = <%- JSON.stringify(collectionActions) %>;
         const jsBaseUrl = '<%= baseUrl %>';

--- a/views/label-sheet.ejs
+++ b/views/label-sheet.ejs
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="<%= locals.currentLng || 'en' %>">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title><%= t('collection.label_sheet_title') %></title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      background: #f4f4f5;
+      color: #111;
+      padding: 24px;
+    }
+    .print-bar {
+      max-width: 900px;
+      margin: 0 auto 20px;
+      display: flex;
+      justify-content: flex-end;
+    }
+    .print-btn {
+      padding: 10px 20px;
+      border: none;
+      border-radius: 6px;
+      background: #2563eb;
+      color: #fff;
+      font-weight: 700;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .sheet {
+      max-width: 900px;
+      margin: 0 auto;
+      column-count: 3;
+      column-gap: 16px;
+    }
+    .label-box {
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 16px;
+      text-align: center;
+      break-inside: avoid;
+      margin-bottom: 16px;
+    }
+    .label-box img {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    .label-box h1 {
+      font-size: 14px;
+      font-weight: 700;
+      margin: 10px 0 2px;
+      line-height: 1.2;
+      word-break: break-word;
+    }
+    .label-box p {
+      font-size: 12px;
+      opacity: .7;
+      margin: 0;
+      word-break: break-word;
+    }
+    @media print {
+      body { background: #fff; padding: 0; }
+      .print-bar { display: none; }
+      .sheet { max-width: none; }
+      .label-box { border: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="print-bar">
+    <button class="print-btn" onclick="window.print()"><%= t('detail.print_label_btn') %></button>
+  </div>
+  <div class="sheet">
+    <% labels.forEach(({ item, plugin, codeDataUrl }) => { %>
+      <%- include('partials/label-box', { item, plugin, codeType, codeDataUrl }) %>
+    <% }) %>
+  </div>
+</body>
+</html>

--- a/views/label.ejs
+++ b/views/label.ejs
@@ -18,7 +18,7 @@
       background: #f4f4f5;
       color: #111;
     }
-    .label {
+    .label-box {
       background: #fff;
       border: 1px solid #ddd;
       border-radius: 8px;
@@ -26,26 +26,31 @@
       width: 260px;
       text-align: center;
     }
-    .label img {
+    .label-box img {
       width: 100%;
       height: auto;
       display: block;
     }
-    .label h1 {
+    .label-box h1 {
       font-size: 14px;
       font-weight: 700;
       margin: 10px 0 2px;
       line-height: 1.2;
       word-break: break-word;
     }
-    .label p {
+    .label-box p {
       font-size: 12px;
       opacity: .7;
       margin: 0;
       word-break: break-word;
     }
-    .print-btn {
+    .actions {
       margin-top: 16px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .print-btn {
       padding: 10px 20px;
       border: none;
       border-radius: 6px;
@@ -55,22 +60,33 @@
       font-size: 14px;
       cursor: pointer;
     }
+    .toggle-link {
+      font-size: 13px;
+      color: #2563eb;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .toggle-link:hover {
+      text-decoration: underline;
+    }
     @media print {
       body { background: #fff; min-height: 0; }
-      .label { border: none; padding: 0; width: 2in; }
-      .print-btn { display: none; }
+      .label-box { border: none; padding: 0; width: 2in; }
+      .actions { display: none; }
     }
   </style>
 </head>
 <body>
-  <div class="label">
-    <img src="<%= qrDataUrl %>" alt="QR code">
-    <h1><%= item.title %></h1>
-    <% const creatorValue = item[plugin.creatorField]; %>
-    <% if (creatorValue) { %>
-      <p><%= creatorValue %></p>
+  <%- include('partials/label-box', { item, plugin, codeType, codeDataUrl }) %>
+  <div class="actions">
+    <button class="print-btn" onclick="window.print()"><%= t('detail.print_label_btn') %></button>
+    <% if (locals.hasBarcode) { %>
+      <% if (codeType === 'barcode') { %>
+        <a class="toggle-link" href="?type=qr"><%= t('detail.switch_to_qr') %></a>
+      <% } else { %>
+        <a class="toggle-link" href="?type=barcode"><%= t('detail.switch_to_barcode') %></a>
+      <% } %>
     <% } %>
   </div>
-  <button class="print-btn" onclick="window.print()"><%= t('detail.print_label_btn') %></button>
 </body>
 </html>

--- a/views/label.ejs
+++ b/views/label.ejs
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="<%= locals.currentLng || 'en' %>">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title><%= item.title %> — <%= t('detail.label_page_title') %></title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f4f4f5;
+      color: #111;
+    }
+    .label {
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 16px;
+      width: 260px;
+      text-align: center;
+    }
+    .label img {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    .label h1 {
+      font-size: 14px;
+      font-weight: 700;
+      margin: 10px 0 2px;
+      line-height: 1.2;
+      word-break: break-word;
+    }
+    .label p {
+      font-size: 12px;
+      opacity: .7;
+      margin: 0;
+      word-break: break-word;
+    }
+    .print-btn {
+      margin-top: 16px;
+      padding: 10px 20px;
+      border: none;
+      border-radius: 6px;
+      background: #2563eb;
+      color: #fff;
+      font-weight: 700;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    @media print {
+      body { background: #fff; min-height: 0; }
+      .label { border: none; padding: 0; width: 2in; }
+      .print-btn { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="label">
+    <img src="<%= qrDataUrl %>" alt="QR code">
+    <h1><%= item.title %></h1>
+    <% const creatorValue = item[plugin.creatorField]; %>
+    <% if (creatorValue) { %>
+      <p><%= creatorValue %></p>
+    <% } %>
+  </div>
+  <button class="print-btn" onclick="window.print()"><%= t('detail.print_label_btn') %></button>
+</body>
+</html>

--- a/views/partials/albums-grid.ejs
+++ b/views/partials/albums-grid.ejs
@@ -24,7 +24,13 @@
         %>
         <div class="album-card group relative card-theme rounded-xl overflow-hidden hover:border-primary-theme transition-all duration-300 hover:shadow-lg hover:-translate-y-1 flex flex-col justify-between"
             data-location="<%= locals.isShareView ? '' : (album.location || '') %>"
-            data-format="<%= album.format || album.media_type || '' %>">
+            data-format="<%= album.format || album.media_type || '' %>"
+            <% if (locals.selectable) { %>data-id="<%= album._id %>"<% } %>>
+            <% if (locals.selectable) { %>
+                <div class="select-checkbox-overlay hidden absolute top-2 left-2 z-20 items-center justify-center w-6 h-6 rounded-md bg-white/90 dark:bg-black/70 border border-black/10 dark:border-white/20 shadow">
+                    <input type="checkbox" class="album-select-checkbox w-[18px] h-[18px] accent-primary-theme cursor-pointer" onclick="event.stopPropagation()" onchange="updateSelectedCount()">
+                </div>
+            <% } %>
             <a href="<%= baseUrl + routePrefix %>/<%= album._id %>" class="block flex-grow">
                 <%- include('item-cover', { item: album, plugin: itemPlugin, gridAspect, settings, badgeSize: locals.badgeSize || '' }) %>
                 <%- include('item-card-body', { item: album, plugin: itemPlugin, size: cardSize, reserveExtraRow: locals.reserveExtraRow === true }) %>

--- a/views/partials/label-box.ejs
+++ b/views/partials/label-box.ejs
@@ -1,0 +1,12 @@
+<%# Label box shared by the single-item label view and the bulk label sheet. One
+    scannable code per box - QR or barcode, never both (the caller picks which to
+    generate).
+    Params: item, plugin, codeType ('qr' | 'barcode'), codeDataUrl %>
+<div class="label-box">
+    <img src="<%= codeDataUrl %>" alt="<%= codeType === 'barcode' ? 'Barcode' : 'QR code' %>">
+    <h1><%= item.title %></h1>
+    <% const creatorValue = item[plugin.creatorField]; %>
+    <% if (creatorValue) { %>
+        <p><%= creatorValue %></p>
+    <% } %>
+</div>


### PR DESCRIPTION
## Summary
- Per-item printable QR label (`GET {plugin.routePrefix}/:id/label`), reachable from a "Print label" button on the item detail page.
- Bulk/sheet printing: a "Select" mode on the collection page (checkbox overlay per card, "Select all" toggle, sticky bulk bar) posts to `POST /collection/labels`, which renders a flowing-column print sheet for up to 200 selected items across mixed item kinds.
- Barcode as an alternative to QR, not shown alongside it: `?type=barcode` on the single-item route, a separate "Print barcode labels" action on the bulk sheet, and one detail-page button with a hover/click QR-vs-barcode dropdown (only offered when the item actually has a barcode value). Falls back to QR wherever a barcode was requested but unavailable, rather than failing.
- New `bwip-js` dependency for Code128 barcode generation (pure JS, no native canvas/Cairo deps, so it doesn't need any Dockerfile changes) - Code128 over EAN/UPC because the stored `barcode` field isn't guaranteed to be a clean, valid-checksum 12/13-digit code.

## Test plan
- [x] `docker compose up -d --build`, log in, confirm the "Print label" button on an item's detail page renders a scannable QR (decodes to the item's detail URL).
- [x] Set a `barcode` value on an item; confirm the detail page now shows a QR/Barcode dropdown (hover, and click as a touch fallback) and both options render/scan correctly.
- [x] On the collection page, click Select, pick a few items (mixed types), Select all/Deselect all, then Print QR labels - confirm the sheet renders one box per item with a working QR.
- [x] With at least one selected item missing a barcode, click Print barcode labels - confirm that item is skipped from the sheet rather than breaking it, and that a selection with *no* barcoded items redirects back to the collection instead of an empty sheet.