### PR TITLE
added clear logic when editing

### DIFF
--- a/core/routes/itemRoutes.ts
+++ b/core/routes/itemRoutes.ts
@@ -459,11 +459,22 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
         const finalQty = isEdit ? qtyToAdd : (existingItem.quantity || 1) + qtyToAdd;
 
         let saveObj: any;
+        let unsetObj: Record<string, ''> = {};
         if (isEdit) {
           saveObj = { ...updateData, quantity: finalQty };
           // Do not reset the added date when editing an existing item
           if (!added_at) {
             saveObj.added_at = existingItem.added_at || new Date();
+          }
+
+          // Unset plugin schema fields when posted as blank strings (including external ids)
+          for (const fieldName of Object.keys(plugin.schemaDefinition)) {
+            const postedValue = req.body[fieldName];
+            const isBlank = postedValue === undefined || (typeof postedValue === 'string' && postedValue.trim() === '') || postedValue === '';
+            if (isBlank && existingItem[fieldName] !== undefined && existingItem[fieldName] !== null && existingItem[fieldName] !== '') {
+              unsetObj[fieldName] = '';
+              delete saveObj[fieldName];
+            }
           }
         } else {
           // Duplicate: increment quantity and backfill identifiers/metadata the existing record
@@ -498,9 +509,13 @@ export function createItemRoutes(plugin: PluginDefinition): Router {
         // id into "1396", which then matched nothing that looked it up as a number.
         // `strict: false` still lets the user-defined `extra.*` keys through.
         const EditModel = mongoose.model(plugin.kind);
+        const updateDoc: any = { $set: { ...saveObj, ...editStamp(adminId) } };
+        if (Object.keys(unsetObj).length > 0) {
+          updateDoc.$unset = unsetObj;
+        }
         await EditModel.updateOne(
           { _id: existingItem._id },
-          { $set: { ...saveObj, ...editStamp(adminId) } },
+          updateDoc,
           { strict: false }
         );
       } else {

--- a/core/views/edit.ejs
+++ b/core/views/edit.ejs
@@ -64,7 +64,7 @@
                         to attach it later to unlock the metadata refresh and the estimate.
                         Skipped when the plugin already declares the id among its form fields
                         (lego's set number), which would otherwise print the input twice.
-                        An emptied input changes nothing: save-<plugin> ignores blank ids. %>
+                        In edit mode, clearing the input removes the stored id from DB. %>
                     <%
                         const extIdField = plugin.externalIdField;
                         const extIdInForm = extIdField


### PR DESCRIPTION
<!-- Thanks for contributing to DVinyl! 🙌 Fill in the sections below so I can review quickly. -->

## What does this PR do?

When editing a record, blank fields clear the field in the db when saving, instead of the change being ignored.

## Related issue

#141 

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧩 New or updated plugin
- [ ] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🧹 Refactor or chore

## Checklist

- [x] `make typecheck` passes
- [x] I tested my changes locally
- [ ] I updated the docs or translations if needed
- [x] My change is focused on a single thing

## Screenshots

<!-- If your change affects the UI, drop a before/after screenshot here. -->

## Anything else?

<!-- Notes, open questions, things you are unsure about. All welcome. -->
